### PR TITLE
Add benchmarks, copied from Abseil

### DIFF
--- a/cwisstable.h
+++ b/cwisstable.h
@@ -1430,7 +1430,7 @@ static inline CWISS_RawHashSet CWISS_RawHashSet_dup(
   CWISS_RawHashSet_reserve(policy, &self, that->size_);
   // Because the table is guaranteed to be empty, we can do something faster
   // than a full `insert`.
-  CWISS_RawIter iter = CWISS_RawHashSet_iter(policy, &self);
+  CWISS_RawIter iter = CWISS_RawHashSet_citer(policy, that);
   void* v;
   while ((v = CWISS_RawIter_next(policy, &iter))) {
     size_t hash = policy->key->hash(v);

--- a/test/BUILD
+++ b/test/BUILD
@@ -40,3 +40,23 @@ cc_test(
       #"-DSWISS_HAVE_SSE2=0",
     ],
 )
+
+cc_binary(
+    name = "raw_hash_set_benchmark",
+    testonly = 1,
+    srcs = ["absl_raw_hash_set_benchmark.cc"],
+    tags = ["benchmark"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//:cwisstable",
+        "//:cwisstable_debug",
+        ":wrappers",
+        
+        "@com_google_absl//absl/strings:str_format",
+        "@com_github_google_benchmark//:benchmark_main",
+    ],
+    copts = [
+      "-std=c++17",
+      #"-DSWISS_HAVE_SSE2=0",
+    ],
+)

--- a/test/absl_raw_hash_set_benchmark.cc
+++ b/test/absl_raw_hash_set_benchmark.cc
@@ -1,0 +1,342 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// absl::raw_hash_set's benchmarks modified to run over cwisstable.
+
+// clang-format off
+#include "cwisstable.h"
+#include "test/wrappers.h"
+// clang-format on
+
+#include <deque>
+#include <numeric>
+#include <utility>
+#include <random>
+
+#include "absl/strings/str_format.h"
+#include "benchmark/benchmark.h"
+
+namespace cwisstable::internal {
+namespace {
+
+using IntTable = raw_hash_set<int64_t, FlatSetPolicy<int64_t>>;
+using StringTable = raw_hash_set<std::string, FlatSetPolicy<std::string>>;
+
+struct string_generator {
+  template <class RNG>
+  std::string operator()(RNG& rng) const {
+    std::string res;
+    res.resize(12);
+    std::uniform_int_distribution<uint32_t> printable_ascii(0x20, 0x7E);
+    std::generate(res.begin(), res.end(), [&] { return printable_ascii(rng); });
+    return res;
+  }
+
+  size_t size;
+};
+
+// Model a cache in steady state.
+//
+// On a table of size N, keep deleting the LRU entry and add a random one.
+void BM_CacheInSteadyState(benchmark::State& state) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  string_generator gen{12};
+  StringTable t;
+  std::deque<std::string> keys;
+  while (t.size() < state.range(0)) {
+    auto x = t.emplace(gen(rng));
+    if (x.second) keys.push_back(*x.first);
+  }
+  CWISS_CHECK(state.range(0) >= 10, "");
+  while (state.KeepRunning()) {
+    // Some cache hits.
+    std::deque<std::string>::const_iterator it;
+    for (int i = 0; i != 90; ++i) {
+      if (i % 10 == 0) it = keys.end();
+      ::benchmark::DoNotOptimize(t.find(*--it));
+    }
+    // Some cache misses.
+    for (int i = 0; i != 10; ++i) ::benchmark::DoNotOptimize(t.find(gen(rng)));
+    CWISS_CHECK(t.erase(keys.front()), keys.front().c_str());
+    keys.pop_front();
+    while (true) {
+      auto x = t.emplace(gen(rng));
+      if (x.second) {
+        keys.push_back(*x.first);
+        break;
+      }
+    }
+  }
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel(absl::StrFormat("load_factor=%.2f", t.load_factor()));
+}
+
+template <typename Benchmark>
+void CacheInSteadyStateArgs(Benchmark* bm) {
+  // The default.
+  const float max_load_factor = 0.875;
+  // When the cache is at the steady state, the probe sequence will equal
+  // capacity if there is no reclamation of deleted slots. Pick a number large
+  // enough to make the benchmark slow for that case.
+  const size_t capacity = 1 << 10;
+
+  // Check N data points to cover load factors in [0.4, 0.8).
+  const size_t kNumPoints = 10;
+  for (size_t i = 0; i != kNumPoints; ++i)
+    bm->Arg(std::ceil(
+        capacity * (max_load_factor + i * max_load_factor / kNumPoints) / 2));
+}
+BENCHMARK(BM_CacheInSteadyState)->Apply(CacheInSteadyStateArgs);
+
+void BM_EndComparison(benchmark::State& state) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  string_generator gen{12};
+  StringTable t;
+  while (t.size() < state.range(0)) {
+    t.emplace(gen(rng));
+  }
+
+  for (auto _ : state) {
+    for (auto it = t.begin(); it != t.end(); ++it) {
+// This is miscompiled by GCC, so the benchmark will be messed up on that
+// compiler.
+#if !defined(__GNUC__) || defined(__clang__)
+      benchmark::DoNotOptimize(it);
+#endif
+      benchmark::DoNotOptimize(t);
+      benchmark::DoNotOptimize(it != t.end());
+    }
+  }
+}
+BENCHMARK(BM_EndComparison)->Arg(400);
+
+void BM_CopyCtor(benchmark::State& state) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  IntTable t;
+  std::uniform_int_distribution<uint64_t> dist(0, ~uint64_t{});
+
+  while (t.size() < state.range(0)) {
+    t.emplace(dist(rng));
+  }
+
+  for (auto _ : state) {
+    IntTable t2 = t;
+    benchmark::DoNotOptimize(t2);
+  }
+}
+BENCHMARK(BM_CopyCtor)->Range(128, 4096);
+
+void BM_CopyAssign(benchmark::State& state) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  IntTable t;
+  std::uniform_int_distribution<uint64_t> dist(0, ~uint64_t{});
+  while (t.size() < state.range(0)) {
+    t.emplace(dist(rng));
+  }
+
+  IntTable t2;
+  for (auto _ : state) {
+    t2 = t;
+    benchmark::DoNotOptimize(t2);
+  }
+}
+BENCHMARK(BM_CopyAssign)->Range(128, 4096);
+
+void BM_RangeCtor(benchmark::State& state) {
+  std::random_device rd;
+  std::mt19937 rng(rd());
+  std::uniform_int_distribution<uint64_t> dist(0, ~uint64_t{});
+  std::vector<int> values;
+  const size_t desired_size = state.range(0);
+  while (values.size() < desired_size) {
+    values.emplace_back(dist(rng));
+  }
+
+  for (auto unused : state) {
+    IntTable t(values.begin(), values.end());
+    benchmark::DoNotOptimize(t);
+  }
+}
+BENCHMARK(BM_RangeCtor)->Range(128, 65536);
+
+void BM_NoOpReserveIntTable(benchmark::State& state) {
+  IntTable t;
+  t.reserve(100000);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(t);
+    t.reserve(100000);
+  }
+}
+BENCHMARK(BM_NoOpReserveIntTable);
+
+void BM_NoOpReserveStringTable(benchmark::State& state) {
+  StringTable t;
+  t.reserve(100000);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(t);
+    t.reserve(100000);
+  }
+}
+BENCHMARK(BM_NoOpReserveStringTable);
+
+void BM_ReserveIntTable(benchmark::State& state) {
+  int reserve_size = state.range(0);
+  for (auto _ : state) {
+    state.PauseTiming();
+    IntTable t;
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(t);
+    t.reserve(reserve_size);
+  }
+}
+BENCHMARK(BM_ReserveIntTable)->Range(128, 4096);
+
+void BM_ReserveStringTable(benchmark::State& state) {
+  int reserve_size = state.range(0);
+  for (auto _ : state) {
+    state.PauseTiming();
+    StringTable t;
+    state.ResumeTiming();
+    benchmark::DoNotOptimize(t);
+    t.reserve(reserve_size);
+  }
+}
+BENCHMARK(BM_ReserveStringTable)->Range(128, 4096);
+
+// Like std::iota, except that ctrl_t doesn't support operator++.
+template <typename CtrlIter>
+void Iota(CtrlIter begin, CtrlIter end, int value) {
+  for (; begin != end; ++begin, ++value) {
+    *begin = static_cast<ctrl_t>(value);
+  }
+}
+
+void BM_Group_Match(benchmark::State& state) {
+  std::array<ctrl_t, Group::kWidth> group;
+  Iota(group.begin(), group.end(), -4);
+  Group g{group.data()};
+  h2_t h = 1;
+  for (auto _ : state) {
+    ::benchmark::DoNotOptimize(h);
+    ::benchmark::DoNotOptimize(g);
+    ::benchmark::DoNotOptimize(g.Match(h));
+  }
+}
+BENCHMARK(BM_Group_Match);
+
+void BM_Group_MatchEmpty(benchmark::State& state) {
+  std::array<ctrl_t, Group::kWidth> group;
+  Iota(group.begin(), group.end(), -4);
+  Group g{group.data()};
+  for (auto _ : state) {
+    ::benchmark::DoNotOptimize(g);
+    ::benchmark::DoNotOptimize(g.MatchEmpty());
+  }
+}
+BENCHMARK(BM_Group_MatchEmpty);
+
+void BM_Group_MatchEmptyOrDeleted(benchmark::State& state) {
+  std::array<ctrl_t, Group::kWidth> group;
+  Iota(group.begin(), group.end(), -4);
+  Group g{group.data()};
+  for (auto _ : state) {
+    ::benchmark::DoNotOptimize(g);
+    ::benchmark::DoNotOptimize(g.MatchEmptyOrDeleted());
+  }
+}
+BENCHMARK(BM_Group_MatchEmptyOrDeleted);
+
+void BM_Group_CountLeadingEmptyOrDeleted(benchmark::State& state) {
+  std::array<ctrl_t, Group::kWidth> group;
+  Iota(group.begin(), group.end(), -2);
+  Group g{group.data()};
+  for (auto _ : state) {
+    ::benchmark::DoNotOptimize(g);
+    ::benchmark::DoNotOptimize(g.CountLeadingEmptyOrDeleted());
+  }
+}
+BENCHMARK(BM_Group_CountLeadingEmptyOrDeleted);
+
+void BM_Group_MatchFirstEmptyOrDeleted(benchmark::State& state) {
+  std::array<ctrl_t, Group::kWidth> group;
+  Iota(group.begin(), group.end(), -2);
+  Group g{group.data()};
+  for (auto _ : state) {
+    ::benchmark::DoNotOptimize(g);
+    ::benchmark::DoNotOptimize(*g.MatchEmptyOrDeleted());
+  }
+}
+BENCHMARK(BM_Group_MatchFirstEmptyOrDeleted);
+
+void BM_DropDeletes(benchmark::State& state) {
+  constexpr size_t capacity = (1 << 20) - 1;
+  std::vector<ctrl_t> ctrl(capacity + 1 + Group::kWidth);
+  ctrl[capacity] = ctrl_t::kSentinel;
+  std::vector<ctrl_t> pattern = {ctrl_t::kEmpty,   static_cast<ctrl_t>(2),
+                                 ctrl_t::kDeleted, static_cast<ctrl_t>(2),
+                                 ctrl_t::kEmpty,   static_cast<ctrl_t>(1),
+                                 ctrl_t::kDeleted};
+  for (size_t i = 0; i != capacity; ++i) {
+    ctrl[i] = pattern[i % pattern.size()];
+  }
+  while (state.KeepRunning()) {
+    state.PauseTiming();
+    std::vector<ctrl_t> ctrl_copy = ctrl;
+    state.ResumeTiming();
+    ConvertDeletedToEmptyAndFullToDeleted(ctrl_copy.data(), capacity);
+    ::benchmark::DoNotOptimize(ctrl_copy[capacity]);
+  }
+}
+BENCHMARK(BM_DropDeletes);
+
+}  // namespace
+}  // namespace cwisstable::internal
+
+// These methods are here to make it easy to examine the assembly for targeted
+// parts of the API.
+auto CodegenAbslRawHashSetInt64Find(cwisstable::internal::IntTable* table,
+                                    int64_t key) -> decltype(table->find(key)) {
+  return table->find(key);
+}
+
+bool CodegenAbslRawHashSetInt64FindNeEnd(cwisstable::internal::IntTable* table,
+                                         int64_t key) {
+  return table->find(key) != table->end();
+}
+
+auto CodegenAbslRawHashSetInt64Insert(cwisstable::internal::IntTable* table,
+                                      int64_t key)
+    -> decltype(table->insert(key)) {
+  return table->insert(key);
+}
+
+bool CodegenAbslRawHashSetInt64Contains(cwisstable::internal::IntTable* table,
+                                        int64_t key) {
+  return table->contains(key);
+}
+
+void CodegenAbslRawHashSetInt64Iterate(cwisstable::internal::IntTable* table) {
+  for (auto x : *table) benchmark::DoNotOptimize(x);
+}
+
+int odr =
+    (::benchmark::DoNotOptimize(std::make_tuple(
+         &CodegenAbslRawHashSetInt64Find, &CodegenAbslRawHashSetInt64FindNeEnd,
+         &CodegenAbslRawHashSetInt64Insert, &CodegenAbslRawHashSetInt64Contains,
+         &CodegenAbslRawHashSetInt64Iterate)),
+     1);

--- a/test/absl_raw_hash_set_test.cc
+++ b/test/absl_raw_hash_set_test.cc
@@ -14,6 +14,11 @@
 
 // absl::raw_hash_set's tests modified to run over cwisstable.
 
+// clang-format off
+#include "cwisstable.h"
+#include "test/wrappers.h"
+// clang-format on
+
 #include <atomic>
 #include <cmath>
 #include <cstdint>
@@ -28,10 +33,8 @@
 
 #include "absl/base/attributes.h"
 #include "absl/base/config.h"
-#include "cwisstable.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "test/wrappers.h"
 //#include "absl/base/internal/cycleclock.h"
 //#include "absl/base/internal/raw_logging.h"
 //#include "absl/container/internal/container_memory.h"


### PR DESCRIPTION
Here's the results using Clang 11:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                 2232 ns         2232 ns       309159 items_per_second=448.102k/s load_factor=0.59
BM_CacheInSteadyState/493                 2224 ns         2224 ns       320068 items_per_second=449.731k/s load_factor=0.61
BM_CacheInSteadyState/538                 2214 ns         2214 ns       322539 items_per_second=451.694k/s load_factor=0.62
BM_CacheInSteadyState/583                 2215 ns         2215 ns       322032 items_per_second=451.522k/s load_factor=0.62
BM_CacheInSteadyState/628                 2212 ns         2212 ns       322424 items_per_second=452.158k/s load_factor=0.62
BM_CacheInSteadyState/672                 2218 ns         2217 ns       322225 items_per_second=450.972k/s load_factor=0.62
BM_CacheInSteadyState/717                 2214 ns         2214 ns       322496 items_per_second=451.617k/s load_factor=0.62
BM_CacheInSteadyState/762                 2229 ns         2229 ns       322047 items_per_second=448.711k/s load_factor=0.62
BM_CacheInSteadyState/807                 2216 ns         2216 ns       322067 items_per_second=451.294k/s load_factor=0.62
BM_CacheInSteadyState/852                 2228 ns         2228 ns       317848 items_per_second=448.859k/s load_factor=0.61
BM_EndComparison/400                      3709 ns         3709 ns       180071
BM_CopyCtor/128                            903 ns          903 ns       744500
BM_CopyCtor/512                           3880 ns         3880 ns       179235
BM_CopyCtor/4096                         37252 ns        37250 ns        18846
BM_CopyAssign/128                          888 ns          888 ns       765713
BM_CopyAssign/512                         3969 ns         3968 ns       180412
BM_CopyAssign/4096                       37720 ns        37718 ns        19104
BM_RangeCtor/128                          2016 ns         2016 ns       349198
BM_RangeCtor/512                          7729 ns         7729 ns        91334
BM_RangeCtor/4096                        63973 ns        63971 ns        11215
BM_RangeCtor/32768                      536555 ns       536539 ns         1308
BM_RangeCtor/65536                     1138317 ns      1138290 ns          619
BM_NoOpReserveIntTable                   0.298 ns        0.298 ns   1000000000
BM_NoOpReserveStringTable                0.298 ns        0.298 ns   1000000000
BM_ReserveIntTable/128                     324 ns          324 ns      2863146
BM_ReserveIntTable/512                     224 ns          225 ns      2465474
BM_ReserveIntTable/4096                    270 ns          271 ns      2565834
BM_ReserveStringTable/128                  219 ns          220 ns      3142603
BM_ReserveStringTable/512                  224 ns          225 ns      3043189
BM_ReserveStringTable/4096                 267 ns          268 ns      2597648
BM_Group_Match                           0.541 ns        0.541 ns   1000000000
BM_Group_MatchEmpty                      0.476 ns        0.476 ns   1000000000
BM_Group_MatchEmptyOrDeleted             0.478 ns        0.478 ns   1000000000
BM_Group_CountLeadingEmptyOrDeleted      0.952 ns        0.952 ns    734777535
BM_Group_MatchFirstEmptyOrDeleted        0.713 ns        0.713 ns    983451904
BM_DropDeletes                           32562 ns        32551 ns        21400
```

Here's the same output from Abseil:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                 2781 ns         2781 ns       247619 items_per_second=359.633k/s load_factor=0.44
BM_CacheInSteadyState/493                 2741 ns         2741 ns       255531 items_per_second=364.776k/s load_factor=0.48
BM_CacheInSteadyState/538                 2751 ns         2751 ns       253919 items_per_second=363.508k/s load_factor=0.53
BM_CacheInSteadyState/583                 2765 ns         2765 ns       253144 items_per_second=361.687k/s load_factor=0.57
BM_CacheInSteadyState/628                 2773 ns         2773 ns       252960 items_per_second=360.669k/s load_factor=0.61
BM_CacheInSteadyState/672                 2778 ns         2778 ns       250945 items_per_second=359.985k/s load_factor=0.66
BM_CacheInSteadyState/717                 2833 ns         2833 ns       249320 items_per_second=352.995k/s load_factor=0.70
BM_CacheInSteadyState/762                 2851 ns         2851 ns       244764 items_per_second=350.786k/s load_factor=0.74
BM_CacheInSteadyState/807                 2735 ns         2735 ns       256760 items_per_second=365.677k/s load_factor=0.39
BM_CacheInSteadyState/852                 2748 ns         2748 ns       256493 items_per_second=363.846k/s load_factor=0.42
BM_EndComparison/400                      1060 ns         1060 ns       669219
BM_CopyCtor/128                            787 ns          787 ns       881932
BM_CopyCtor/512                           3517 ns         3517 ns       200668
BM_CopyCtor/4096                         29573 ns        29570 ns        22948
BM_CopyAssign/128                          972 ns          972 ns       717030
BM_CopyAssign/512                         3646 ns         3646 ns       192541
BM_CopyAssign/4096                       31746 ns        31744 ns        21872
BM_RangeCtor/128                           864 ns          864 ns       805573
BM_RangeCtor/512                          3321 ns         3321 ns       214459
BM_RangeCtor/4096                        26328 ns        26327 ns        26564
BM_RangeCtor/32768                      236531 ns       236504 ns         2971
BM_RangeCtor/65536                      508034 ns       508021 ns         1375
BM_NoOpReserveIntTable                   0.298 ns        0.298 ns   1000000000
BM_NoOpReserveStringTable                0.299 ns        0.299 ns   1000000000
BM_ReserveIntTable/128                     211 ns          213 ns      3305282
BM_ReserveIntTable/512                     204 ns          205 ns      3437311
BM_ReserveIntTable/4096                    252 ns          253 ns      2769420
BM_ReserveStringTable/128                  335 ns          337 ns      2063183
BM_ReserveStringTable/512                  700 ns          702 ns       994710
BM_ReserveStringTable/4096                4149 ns         4150 ns       168774
BM_Group_Match                           0.529 ns        0.529 ns   1000000000
BM_Group_MatchEmpty                      0.237 ns        0.237 ns   1000000000
BM_Group_MatchEmptyOrDeleted             0.237 ns        0.237 ns   1000000000
BM_Group_CountLeadingEmptyOrDeleted      0.945 ns        0.945 ns    739763501
BM_Group_MatchFirstEmptyOrDeleted        0.712 ns        0.712 ns    984603599
BM_DropDeletes                           31881 ns        31885 ns        22013
```

With clang, we appear to take a 2x performance hit! CacheInSteadyState is about the same because our version is a set, not a map, using only a single std::string.

GCC 10, on the other hand, puts them on par. Note that EndComparison is miscompiled on GCC.

Ours:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                 3654 ns         3654 ns       195743 items_per_second=273.666k/s load_factor=0.75
BM_CacheInSteadyState/493                 3498 ns         3498 ns       199919 items_per_second=285.879k/s load_factor=0.76
BM_CacheInSteadyState/538                 3487 ns         3487 ns       200594 items_per_second=286.764k/s load_factor=0.77
BM_CacheInSteadyState/583                 3498 ns         3497 ns       200677 items_per_second=285.937k/s load_factor=0.77
BM_CacheInSteadyState/628                 3500 ns         3500 ns       200473 items_per_second=285.746k/s load_factor=0.77
BM_CacheInSteadyState/672                 3495 ns         3495 ns       200936 items_per_second=286.138k/s load_factor=0.77
BM_CacheInSteadyState/717                 3489 ns         3489 ns       200725 items_per_second=286.612k/s load_factor=0.77
BM_CacheInSteadyState/762                 3490 ns         3490 ns       200524 items_per_second=286.57k/s load_factor=0.77
BM_CacheInSteadyState/807                 3497 ns         3497 ns       200474 items_per_second=285.979k/s load_factor=0.77
BM_CacheInSteadyState/852                 3492 ns         3492 ns       199342 items_per_second=286.369k/s load_factor=0.76
BM_EndComparison/400                      1404 ns         1403 ns       567467
BM_CopyCtor/128                           1059 ns         1058 ns       640524
BM_CopyCtor/512                           4294 ns         4294 ns       161440
BM_CopyCtor/4096                         35340 ns        35336 ns        19843
BM_CopyAssign/128                         1059 ns         1059 ns       657347
BM_CopyAssign/512                         4365 ns         4365 ns       161204
BM_CopyAssign/4096                       35335 ns        35333 ns        19723
BM_RangeCtor/128                          1626 ns         1625 ns       416731
BM_RangeCtor/512                          6641 ns         6641 ns       108411
BM_RangeCtor/4096                        51736 ns        51734 ns        13550
BM_RangeCtor/32768                      450926 ns       450917 ns         1557
BM_RangeCtor/65536                      970027 ns       969893 ns          729
BM_NoOpReserveIntTable                   0.470 ns        0.470 ns   1000000000
BM_NoOpReserveStringTable                0.469 ns        0.469 ns   1000000000
BM_ReserveIntTable/128                     220 ns          222 ns      3176938
BM_ReserveIntTable/512                     209 ns          210 ns      3317878
BM_ReserveIntTable/4096                    256 ns          258 ns      2734051
BM_ReserveStringTable/128                  208 ns          209 ns      3372560
BM_ReserveStringTable/512                  210 ns          211 ns      3310008
BM_ReserveStringTable/4096                 261 ns          263 ns      2700252
BM_Group_Match                            2.07 ns         2.03 ns    355478853
BM_Group_MatchEmpty                       2.01 ns         2.01 ns    342197416
BM_Group_MatchEmptyOrDeleted              1.90 ns         1.90 ns    363496692
BM_Group_CountLeadingEmptyOrDeleted       1.93 ns         1.93 ns    354012034
BM_Group_MatchFirstEmptyOrDeleted         1.89 ns         1.89 ns    369066830
BM_DropDeletes                           26443 ns        26430 ns        26620
```

Abseil's:
```
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                 3219 ns         3219 ns       215551 items_per_second=310.643k/s load_factor=0.44
BM_CacheInSteadyState/493                 3178 ns         3178 ns       218778 items_per_second=314.7k/s load_factor=0.48
BM_CacheInSteadyState/538                 3184 ns         3184 ns       220123 items_per_second=314.117k/s load_factor=0.53
BM_CacheInSteadyState/583                 3192 ns         3192 ns       219408 items_per_second=313.281k/s load_factor=0.57
BM_CacheInSteadyState/628                 3196 ns         3196 ns       218619 items_per_second=312.874k/s load_factor=0.61
BM_CacheInSteadyState/672                 3218 ns         3218 ns       217704 items_per_second=310.789k/s load_factor=0.66
BM_CacheInSteadyState/717                 3239 ns         3239 ns       215716 items_per_second=308.783k/s load_factor=0.70
BM_CacheInSteadyState/762                 3270 ns         3270 ns       214419 items_per_second=305.817k/s load_factor=0.74
BM_CacheInSteadyState/807                 3172 ns         3172 ns       220473 items_per_second=315.24k/s load_factor=0.39
BM_CacheInSteadyState/852                 3218 ns         3218 ns       219759 items_per_second=310.717k/s load_factor=0.42
BM_EndComparison/400                       445 ns          445 ns      1599732
BM_CopyCtor/128                            737 ns          737 ns       919820
BM_CopyCtor/512                           3431 ns         3430 ns       202455
BM_CopyCtor/4096                         25420 ns        25419 ns        27220
BM_CopyAssign/128                          850 ns          850 ns       835429
BM_CopyAssign/512                         3729 ns         3729 ns       188703
BM_CopyAssign/4096                       27333 ns        27333 ns        25649
BM_RangeCtor/128                           826 ns          826 ns       903980
BM_RangeCtor/512                          2990 ns         2990 ns       229992
BM_RangeCtor/4096                        25182 ns        25181 ns        28377
BM_RangeCtor/32768                      220809 ns       220795 ns         3174
BM_RangeCtor/65536                      477403 ns       477389 ns         1463
BM_NoOpReserveIntTable                   0.472 ns        0.472 ns   1000000000
BM_NoOpReserveStringTable                0.472 ns        0.472 ns   1000000000
BM_ReserveIntTable/128                     214 ns          215 ns      3241154
BM_ReserveIntTable/512                     206 ns          207 ns      3367336
BM_ReserveIntTable/4096                    252 ns          254 ns      2741430
BM_ReserveStringTable/128                  278 ns          280 ns      2507610
BM_ReserveStringTable/512                  466 ns          467 ns      1496864
BM_ReserveStringTable/4096                2231 ns         2232 ns       313415
BM_Group_Match                            1.87 ns         1.87 ns    374214578
BM_Group_MatchEmpty                       1.87 ns         1.87 ns    374817934
BM_Group_MatchEmptyOrDeleted              1.88 ns         1.88 ns    373993675
BM_Group_CountLeadingEmptyOrDeleted       1.88 ns         1.88 ns    370733499
BM_Group_MatchFirstEmptyOrDeleted         1.87 ns         1.87 ns    372861128
BM_DropDeletes                           32630 ns        32635 ns        21507
```

I suspect the difference here is that Clang is not inlining as aggressively as it needs to, from comparing generated assembly. For example, the GCC codegen for `CodegenAbslRawHashSetInt64FindNeEnd` is vastly more flat.