### PR TITLE
Implement heterogenous lookup and erasure

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(
+    "//:copts.bzl",
+    "CWISS_DEFAULT_COPTS",
+    "CWISS_DEFAULT_LINKOPTS",
+    "CWISS_C_VERSION",
+    "CWISS_CXX_VERSION",
+)
+
 filegroup(
     name = "public_headers",
     srcs = [
@@ -34,10 +42,12 @@ filegroup(
 )
 
 cc_library(
-  name = "split",
-  hdrs = [":public_headers"],
-  srcs = [":private_headers"],
-  visibility = ["//visibility:public"],
+    name = "split",
+    hdrs = [":public_headers"],
+    srcs = [":private_headers"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
 )
 
 genrule(
@@ -58,15 +68,37 @@ genrule(
 )
 
 cc_library(
-  name = "unified",
-  hdrs = ["cwisstable.h"],
-  visibility = ["//visibility:public"],
+    name = "unified",
+    hdrs = ["cwisstable.h"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "debug",
     hdrs = ["cwisstable/internal/debug.h"],
     srcs = ["cwisstable/internal/debug.cc"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_CXX_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     deps = [":unified"],
     visibility = ["//:__subpackages__"],
+)
+
+config_setting(
+    name = "clang_compiler",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
+    name = "msvc_compiler",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "mscv-cl"},
+    visibility = [":__subpackages__"],
+)
+
+config_setting(
+    name = "clang-cl_compiler",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang-cl"},
+    visibility = [":__subpackages__"],
 )

--- a/copts.bzl
+++ b/copts.bzl
@@ -1,0 +1,193 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# C/C++ compiler options selection. Taken from Abseil.
+
+CWISS_CLANG_CL_FLAGS = [
+    "/W3",
+    "/DNOMINMAX",
+    "/DWIN32_LEAN_AND_MEAN",
+    "/D_CRT_SECURE_NO_WARNINGS",
+    "/D_SCL_SECURE_NO_WARNINGS",
+    "/D_ENABLE_EXTENDED_ALIGNED_STORAGE",
+]
+
+CWISS_CLANG_CL_TEST_FLAGS = [
+    "-Wno-c99-extensions",
+    "-Wno-deprecated-declarations",
+    "-Wno-missing-noreturn",
+    "-Wno-missing-prototypes",
+    "-Wno-missing-variable-declarations",
+    "-Wno-null-conversion",
+    "-Wno-shadow",
+    "-Wno-shift-sign-overflow",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unused-member-function",
+    "-Wno-unused-parameter",
+    "-Wno-unused-private-field",
+    "-Wno-unused-template",
+    "-Wno-used-but-marked-unused",
+    "-Wno-zero-as-null-pointer-constant",
+    "-Wno-gnu-zero-variadic-macro-arguments",
+]
+
+CWISS_GCC_FLAGS = [
+    "-Werror",
+    "-Wall",
+    "-Wextra",
+    "-Wcast-qual",
+    # The cc1 driver whines about this in C mode.
+    # "-Wconversion-null",
+    "-Wformat-security",
+    "-Wmissing-declarations",
+    "-Woverlength-strings",
+    "-Wpointer-arith",
+    "-Wundef",
+    "-Wunused-local-typedefs",
+    "-Wunused-result",
+    "-Wvarargs",
+    "-Wvla",
+    "-Wwrite-strings",
+    "-DNOMINMAX",
+]
+
+CWISS_GCC_TEST_FLAGS = [
+    "-Wno-conversion-null",
+    "-Wno-deprecated-declarations",
+    "-Wno-missing-declarations",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unused-parameter",
+    "-Wno-unused-private-field",
+]
+
+CWISS_LLVM_FLAGS = [
+    "-Werror",
+    "-Wall",
+    "-Wextra",
+    "-Wcast-qual",
+    "-Wconversion",
+    "-Wfloat-overflow-conversion",
+    "-Wfloat-zero-conversion",
+    "-Wfor-loop-analysis",
+    "-Wformat-security",
+    "-Wgnu-redeclared-enum",
+    "-Winfinite-recursion",
+    "-Winvalid-constexpr",
+    "-Wliteral-conversion",
+    "-Wmissing-declarations",
+    "-Woverlength-strings",
+    "-Wpointer-arith",
+    "-Wself-assign",
+    "-Wshadow-all",
+    "-Wstring-conversion",
+    "-Wtautological-overlap-compare",
+    "-Wundef",
+    "-Wuninitialized",
+    "-Wunreachable-code",
+    "-Wunused-comparison",
+    "-Wunused-local-typedefs",
+    "-Wunused-result",
+    "-Wvla",
+    "-Wwrite-strings",
+    "-Wno-float-conversion",
+    "-Wno-implicit-float-conversion",
+    "-Wno-implicit-int-float-conversion",
+    "-Wno-implicit-int-conversion",
+    "-Wno-shorten-64-to-32",
+    "-Wno-sign-conversion",
+    "-Wno-unknown-warning-option",
+    "-DNOMINMAX",
+]
+
+CWISS_LLVM_TEST_FLAGS = [
+    "-Wno-c99-extensions",
+    "-Wno-deprecated-declarations",
+    "-Wno-missing-noreturn",
+    "-Wno-missing-prototypes",
+    "-Wno-missing-variable-declarations",
+    "-Wno-null-conversion",
+    "-Wno-shadow",
+    "-Wno-shift-sign-overflow",
+    "-Wno-sign-compare",
+    "-Wno-unused-function",
+    "-Wno-unused-member-function",
+    "-Wno-unused-parameter",
+    "-Wno-unused-private-field",
+    "-Wno-unused-template",
+    "-Wno-used-but-marked-unused",
+    "-Wno-zero-as-null-pointer-constant",
+    "-Wno-gnu-zero-variadic-macro-arguments",
+]
+
+CWISS_MSVC_FLAGS = [
+    "/W3",
+    "/DNOMINMAX",
+    "/DWIN32_LEAN_AND_MEAN",
+    "/D_CRT_SECURE_NO_WARNINGS",
+    "/D_SCL_SECURE_NO_WARNINGS",
+    "/D_ENABLE_EXTENDED_ALIGNED_STORAGE",
+    "/bigobj",
+    "/wd4005",
+    "/wd4068",
+    "/wd4180",
+    "/wd4244",
+    "/wd4267",
+    "/wd4503",
+    "/wd4800",
+]
+
+CWISS_MSVC_LINKOPTS = [
+    "-ignore:4221",
+]
+
+CWISS_MSVC_TEST_FLAGS = [
+    "/wd4018",
+    "/wd4101",
+    "/wd4503",
+    "/wd4996",
+    "/DNOMINMAX",
+]
+
+CWISS_DEFAULT_COPTS = select({
+    "//:msvc_compiler": CWISS_MSVC_FLAGS,
+    "//:clang-cl_compiler": CWISS_CLANG_CL_FLAGS,
+    "//:clang_compiler": CWISS_LLVM_FLAGS,
+    "//conditions:default": CWISS_GCC_FLAGS,
+})
+
+CWISS_TEST_COPTS = CWISS_DEFAULT_COPTS + select({
+    "//:msvc_compiler": CWISS_MSVC_TEST_FLAGS,
+    "//:clang-cl_compiler": CWISS_CLANG_CL_TEST_FLAGS,
+    "//:clang_compiler": CWISS_LLVM_TEST_FLAGS,
+    "//conditions:default": CWISS_GCC_TEST_FLAGS,
+})
+
+CWISS_DEFAULT_LINKOPTS = select({
+    "//:msvc_compiler": CWISS_MSVC_LINKOPTS,
+    "//conditions:default": [],
+})
+
+CWISS_CXX_VERSION = select({
+    "//:msvc_compiler": ["/std:c++17"],
+    "//:clang-cl_compiler": ["/std:c++17"],
+    "//conditions:default": ["--std=c++17"],
+})
+
+CWISS_C_VERSION = select({
+    "//:msvc_compiler": ["/std:c11"],
+    "//:clang-cl_compiler": ["/std:c11"],
+    "//conditions:default": ["--std=c11"],
+})

--- a/cwisstable/internal/base.h
+++ b/cwisstable/internal/base.h
@@ -75,18 +75,29 @@
 #define CWISS_IS_GCC (CWISS_IS_GCCISH && !CWISS_IS_CLANG)
 #define CWISS_IS_MSVC (CWISS_IS_MSVCISH && !CWISS_IS_CLANG)
 
+
+#define CWISS_PRAGMA_(pragma_) _Pragma(#pragma_)
+
+#if CWISS_IS_GCCISH
+  #define CWISS_GCC_PUSH_ CWISS_PRAGMA_(GCC diagnostic push)
+  #define CWISS_GCC_ALLOW_(w_) CWISS_PRAGMA_(GCC diagnostic ignored w_)
+  #define CWISS_GCC_POP_ CWISS_PRAGMA_(GCC diagnostic pop)
+#else
+  #define CWISS_GCC_PUSH_
+  #define CWISS_GCC_ALLOW_(warning)
+  #define CWISS_GCC_POP_
+#endif
+
 /// Warning control around `CWISS` symbol definitions. These macros will
 /// disable certain false-positive warnings that `CWISS` definitions tend to
 /// emit.
-#if CWISS_IS_GCCISH
-  #define CWISS_BEGIN_             \
-    _Pragma("GCC diagnostic push") \
-        _Pragma("GCC diagnostic ignored \"-Wunused-function\"")
-  #define CWISS_END_ _Pragma("GCC diagnostic pop")
-#else
-  #define CWISS_BEGIN_
-  #define CWISS_END_
-#endif
+#define CWISS_BEGIN_                     \
+  CWISS_GCC_PUSH_                        \
+  CWISS_GCC_ALLOW_("-Wunused-function")  \
+  CWISS_GCC_ALLOW_("-Wunused-parameter") \
+  CWISS_GCC_ALLOW_("-Wcast-qual")        \
+  CWISS_GCC_ALLOW_("-Wmissing-field-initializers")
+#define CWISS_END_ CWISS_GCC_POP_
 
 /// `CWISS_HAVE_SSE2` is nonzero if we have SSE2 support.
 ///

--- a/cwisstable/internal/base.h
+++ b/cwisstable/internal/base.h
@@ -75,7 +75,6 @@
 #define CWISS_IS_GCC (CWISS_IS_GCCISH && !CWISS_IS_CLANG)
 #define CWISS_IS_MSVC (CWISS_IS_MSVCISH && !CWISS_IS_CLANG)
 
-
 #define CWISS_PRAGMA_(pragma_) _Pragma(#pragma_)
 
 #if CWISS_IS_GCCISH

--- a/cwisstable/internal/ctrl.h
+++ b/cwisstable/internal/ctrl.h
@@ -198,7 +198,7 @@ static inline CWISS_Group CWISS_mm_cmpgt_epi8_fixed(CWISS_Group a,
   return _mm_cmpgt_epi8(a, b);
 }
 
-CWISS_Group CWISS_Group_new(const CWISS_ctrl_t* pos) {
+static inline CWISS_Group CWISS_Group_new(const CWISS_ctrl_t* pos) {
   return _mm_loadu_si128((const CWISS_Group*)pos);
 }
 
@@ -254,7 +254,7 @@ typedef uint64_t CWISS_Group;
   #define CWISS_Group_kShift 3
 
 // NOTE: Endian-hostile.
-CWISS_Group CWISS_Group_new(const CWISS_ctrl_t* pos) {
+static inline CWISS_Group CWISS_Group_new(const CWISS_ctrl_t* pos) {
   CWISS_Group val;
   memcpy(&val, pos, sizeof(val));
   return val;

--- a/cwisstable/internal/debug.h
+++ b/cwisstable/internal/debug.h
@@ -47,7 +47,7 @@ size_t AllocatedByteSize(const CWISS_Policy* policy,
 
 // Returns a tight lower bound for AllocatedByteSize(c) where `c` is of type `C`
 // and `c.size()` is equal to `num_elements`.
-size_t LowerBoundAllocatedByteSize(size_t size);
+size_t LowerBoundAllocatedByteSize(const CWISS_Policy* policy, size_t size);
 
 // Gets a histogram of the number of probes for each elements in the container.
 // The sum of all the values in the vector is equal to container.size().

--- a/cwisstable/internal/raw_hash_set.h
+++ b/cwisstable/internal/raw_hash_set.h
@@ -25,8 +25,8 @@
 #include "cwisstable/internal/bits.h"
 #include "cwisstable/internal/capacity.h"
 #include "cwisstable/internal/ctrl.h"
-#include "cwisstable/policy.h"
 #include "cwisstable/internal/probe.h"
+#include "cwisstable/policy.h"
 
 /// The SwissTable implementation.
 ///

--- a/cwisstable/map_api.h
+++ b/cwisstable/map_api.h
@@ -18,11 +18,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "cwisstable/policy.h"
 #include "cwisstable/declare.h"
+#include "cwisstable/policy.h"
 
 /// Example API expansion of declare.h map macros.
-/// 
+///
 /// Should be kept in sync with declare.h; unfortunately we don't have an easy
 /// way to test this just yet.
 
@@ -32,7 +32,9 @@
 static inline const CWISS_Policy* MyMap_policy();
 
 /// The generated type.
-typedef struct { /* ... */ } MyMap;
+typedef struct {
+  /* ... */
+} MyMap;
 
 /// A key-value pair in the map.
 typedef struct {
@@ -78,7 +80,9 @@ static inline size_t MyMap_capacity(const MyMap* self);
 static inline void MyMap_clear(MyMap* self);
 
 /// A non-mutating iterator into a `MyMap`.
-typedef struct { /* ... */ } MyMap_CIter;
+typedef struct {
+  /* ... */
+} MyMap_CIter;
 
 /// Creates a new non-mutating iterator fro this table.
 static inline MyMap_CIter MyMap_citer(const MyMap* self);
@@ -94,7 +98,9 @@ static inline const MyMap_Entry* MyMap_CIter_get(const MyMap_CIter* it);
 static inline const MyMap_Entry* MyMap_CIter_next(const MyMap_CIter* it);
 
 /// A mutating iterator into a `MyMap`.
-typedef struct { /* ... */ } MyMap_Iter;
+typedef struct {
+  /* ... */
+} MyMap_Iter;
 
 /// Creates a new mutating iterator fro this table.
 static inline MyMap_Iter MyMap_iter(const MyMap* self);
@@ -132,8 +138,8 @@ static inline MyMap_Iter MyMap_find(MyMap* self, const K* key);
 /// Like `MyMap_cfind`, but takes a pre-computed hash.
 ///
 /// The hash must be correct for `key`.
-static inline MyMap_CIter MyMap_cfind_hinted(const MyMap* self,
-                                             const K* key, size_t hash);
+static inline MyMap_CIter MyMap_cfind_hinted(const MyMap* self, const K* key,
+                                             size_t hash);
 
 /// Like `MyMap_find`, but takes a pre-computed hash.
 ///

--- a/cwisstable/map_api.h
+++ b/cwisstable/map_api.h
@@ -172,6 +172,52 @@ static inline void MyMap_erase_at(MyMap_Iter it);
 /// Returns `true` if erasure happened.
 static inline bool MyMap_erase(MyMap* self, const K* key);
 
+// CWISS_DECLARE_LOOKUP(MyMap, View) expands to:
+
+/// Returns the policy used with this lookup extension.
+static inline const CWISS_KeyPolicy* MyMap_View_policy();
+
+/// Checks if this map contains the given element.
+///
+/// In general, if you plan to use the element and not just check for it,
+/// prefer `MyMap_find()` and friends.
+static inline bool MyMap_contains_by_View(const MyMap* self, const View* key);
+
+/// Searches the table for `key`, non-mutating iterator version.
+///
+/// If found, returns an iterator at the found element; otherwise, returns
+/// an iterator that's already at the end: `get()` will return `NULL`.
+static inline MyMap_CIter MyMap_cfind_by_View(const MyMap* self,
+                                              const View* key);
+
+/// Searches the table for `key`, mutating iterator version.
+///
+/// If found, returns an iterator at the found element; otherwise, returns
+/// an iterator that's already at the end: `get()` will return `NULL`.
+///
+/// This function does not trigger rehashes.
+static inline MyMap_Iter MyMap_find_by_View(MyMap* self, const View* key);
+
+/// Like `MyMap_cfind`, but takes a pre-computed hash.
+///
+/// The hash must be correct for `key`.
+static inline MyMap_CIter MyMap_cfind_hinted_by_View(const MyMap* self,
+                                                     const View* key,
+                                                     size_t hash);
+
+/// Like `MyMap_find`, but takes a pre-computed hash.
+///
+/// The hash must be correct for `key`.
+///
+/// This function does not trigger rehashes.
+static inline MyMap_Iter MyMap_find_hinted_by_View(MyMap* self, const View* key,
+                                                   size_t hash);
+
+/// Looks up `key` and erases it from the map.
+///
+/// Returns `true` if erasure happened.
+static inline bool MyMap_erase_by_View(MyMap* self, const View* key);
+
 #error "This file is for demonstration purposes only."
 
 #endif  // CWISSTABLE_MAP_API_H_

--- a/cwisstable/policy.h
+++ b/cwisstable/policy.h
@@ -242,6 +242,7 @@ typedef struct {
 // ---- PUBLIC API ENDS HERE! ----
 
 #define CWISS_DECLARE_POLICY_(kPolicy_, Type_, Key_, ...)                    \
+  CWISS_BEGIN_                                                               \
   static inline void kPolicy_##_DefaultCopy(void* dst, const void* src) {    \
     memcpy(dst, src, sizeof(Type_));                                         \
   }                                                                          \
@@ -287,6 +288,7 @@ typedef struct {
                     __VA_ARGS__),                                            \
       CWISS_EXTRACT(slot_get, kPolicy_##_DefaultSlotGet, __VA_ARGS__),       \
   };                                                                         \
+  CWISS_END_                                                                 \
   static const CWISS_Policy kPolicy_ = {                                     \
       &kPolicy_##_ObjectPolicy,                                              \
       &kPolicy_##_KeyPolicy,                                                 \
@@ -295,6 +297,7 @@ typedef struct {
   }
 
 #define CWISS_DECLARE_NODE_FUNCTIONS_(kPolicy_, Type_, ...)                    \
+  CWISS_BEGIN_                                                                 \
   static inline void kPolicy_##_NodeSlotInit(void* slot) {                     \
     void* node = CWISS_EXTRACT(alloc_alloc, CWISS_DefaultMalloc, __VA_ARGS__)( \
         sizeof(Type_), alignof(Type_));                                        \
@@ -313,7 +316,8 @@ typedef struct {
   }                                                                            \
   static inline void* kPolicy_##_NodeSlotGet(void* slot) {                     \
     return *((void**)slot);                                                    \
-  }
+  }                                                                            \
+  CWISS_END_
 
 #define CWISS_NODE_OVERRIDES_(kPolicy_)                     \
   (slot_size, sizeof(void*)), (slot_align, alignof(void*)), \

--- a/cwisstable/set_api.h
+++ b/cwisstable/set_api.h
@@ -18,11 +18,11 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "cwisstable/policy.h"
 #include "cwisstable/declare.h"
+#include "cwisstable/policy.h"
 
 /// Example API expansion of declare.h set macros.
-/// 
+///
 /// Should be kept in sync with declare.h; unfortunately we don't have an easy
 /// way to test this just yet.
 
@@ -32,7 +32,9 @@
 static inline const CWISS_Policy* MySet_policy();
 
 /// The generated type.
-typedef struct { /* ... */ } MySet;
+typedef struct {
+  /* ... */
+} MySet;
 
 /// Constructs a new set with the given initial capacity.
 static inline MySet MySet_new(size_t capacity);
@@ -72,7 +74,9 @@ static inline size_t MySet_capacity(const MySet* self);
 static inline void MySet_clear(MySet* self);
 
 /// A non-mutating iterator into a `MySet`.
-typedef struct { /* ... */ } MySet_CIter;
+typedef struct {
+  /* ... */
+} MySet_CIter;
 
 /// Creates a new non-mutating iterator fro this table.
 static inline MySet_CIter MySet_citer(const MySet* self);
@@ -88,7 +92,9 @@ static inline const T* MySet_CIter_get(const MySet_CIter* it);
 static inline const T* MySet_CIter_next(const MySet_CIter* it);
 
 /// A mutating iterator into a `MySet`.
-typedef struct { /* ... */ } MySet_Iter;
+typedef struct {
+  /* ... */
+} MySet_Iter;
 
 /// Creates a new mutating iterator fro this table.
 static inline MySet_Iter MySet_iter(const MySet* self);
@@ -126,8 +132,8 @@ static inline MySet_Iter MySet_find(MySet* self, const T* key);
 /// Like `MySet_cfind`, but takes a pre-computed hash.
 ///
 /// The hash must be correct for `key`.
-static inline MySet_CIter MySet_cfind_hinted(const MySet* self,
-                                             const T* key, size_t hash);
+static inline MySet_CIter MySet_cfind_hinted(const MySet* self, const T* key,
+                                             size_t hash);
 
 /// Like `MySet_find`, but takes a pre-computed hash.
 ///

--- a/cwisstable/set_api.h
+++ b/cwisstable/set_api.h
@@ -166,6 +166,52 @@ static inline void MySet_erase_at(MySet_Iter it);
 /// Returns `true` if erasure happened.
 static inline bool MySet_erase(MySet* self, const T* key);
 
+// CWISS_DECLARE_LOOKUP(MySet, View) expands to:
+
+/// Returns the policy used with this lookup extension.
+static inline const CWISS_KeyPolicy* MySet_View_policy(void);
+
+/// Checks if this set contains the given element.
+///
+/// In general, if you plan to use the element and not just check for it,
+/// prefer `MySet_find()` and friends.
+static inline bool MySet_contains_by_View(const MySet* self, const View* key);
+
+/// Searches the table for `key`, non-mutating iterator version.
+///
+/// If found, returns an iterator at the found element; otherwise, returns
+/// an iterator that's already at the end: `get()` will return `NULL`.
+static inline MySet_CIter MySet_cfind_by_View(const MySet* self,
+                                              const View* key);
+
+/// Searches the table for `key`, mutating iterator version.
+///
+/// If found, returns an iterator at the found element; otherwise, returns
+/// an iterator that's already at the end: `get()` will return `NULL`.
+///
+/// This function does not trigger rehashes.
+static inline MySet_Iter MySet_find_by_View(MySet* self, const View* key);
+
+/// Like `MySet_cfind`, but takes a pre-computed hash.
+///
+/// The hash must be correct for `key`.
+static inline MySet_CIter MySet_cfind_hinted_by_View(const MySet* self,
+                                                     const View* key,
+                                                     size_t hash);
+
+/// Like `MySet_find`, but takes a pre-computed hash.
+///
+/// The hash must be correct for `key`.
+///
+/// This function does not trigger rehashes.
+static inline MySet_Iter MySet_find_hinted_by_View(MySet* self, const View* key,
+                                                   size_t hash);
+
+/// Looks up `key` and erases it from the map.
+///
+/// Returns `true` if erasure happened.
+static inline bool MySet_erase_by_View(MySet* self, const View* key);
+
 #error "This file is for demonstration purposes only."
 
 #endif  // CWISSTABLE_SET_API_H_

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -12,11 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(
+    "//:copts.bzl",
+    "CWISS_DEFAULT_COPTS",
+    "CWISS_DEFAULT_LINKOPTS",
+    "CWISS_C_VERSION",
+)
+
 cc_binary(
     name = "hashset_unified",
     srcs = ["hashset.c"],
     deps = ["//:unified"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_UNIFIED"],
 )
 
@@ -24,7 +32,8 @@ cc_binary(
     name = "hashset_split",
     srcs = ["hashset.c"],
     deps = ["//:split"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_SPLIT"],
 )
 
@@ -32,7 +41,8 @@ cc_binary(
     name = "hashmap_unified",
     srcs = ["hashmap.c"],
     deps = ["//:unified"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_UNIFIED"],
 )
 
@@ -40,7 +50,8 @@ cc_binary(
     name = "hashmap_split",
     srcs = ["hashmap.c"],
     deps = ["//:split"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_SPLIT"],
 )
 
@@ -48,7 +59,8 @@ cc_binary(
     name = "stringmap_unified",
     srcs = ["stringmap.c"],
     deps = ["//:unified"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_UNIFIED"],
 )
 
@@ -56,6 +68,7 @@ cc_binary(
     name = "stringmap_split",
     srcs = ["stringmap.c"],
     deps = ["//:split"],
-    copts = ["--std=c11"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
     defines = ["CWISS_EXAMPLE_SPLIT"],
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -20,6 +20,24 @@ load(
 )
 
 cc_binary(
+    name = "arraymap_unified",
+    srcs = ["arraymap.c"],
+    deps = ["//:unified"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
+    defines = ["CWISS_EXAMPLE_UNIFIED"],
+)
+
+cc_binary(
+    name = "arraymap_split",
+    srcs = ["arraymap.c"],
+    deps = ["//:split"],
+    copts = CWISS_DEFAULT_COPTS + CWISS_C_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
+    defines = ["CWISS_EXAMPLE_SPLIT"],
+)
+
+cc_binary(
     name = "hashset_unified",
     srcs = ["hashset.c"],
     deps = ["//:unified"],

--- a/examples/arraymap.c
+++ b/examples/arraymap.c
@@ -1,0 +1,197 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file demonstrates the heterogenous lookup API.
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(CWISS_EXAMPLE_UNIFIED)
+  #include "cwisstable.h"
+#elif defined(CWISS_EXAMPLE_SPLIT)
+  #include "cwisstable/declare.h"
+  #include "cwisstable/policy.h"
+#else
+  #error "must set CWISS_EXAMPLE_UNIFIED or CWISS_EXAMPLE_SPLIT"
+#endif
+
+typedef struct {
+  int* ptr;
+  size_t len, cap;
+} IntArray;
+
+typedef struct {
+  int* ptr;
+  size_t len;
+} IntView;
+
+static IntArray IntArray_new(void) { return (IntArray){0}; }
+
+static IntArray IntArray_dup(const IntArray* self) {
+  IntArray array = {
+      malloc(self->cap * sizeof(int)),
+      self->len,
+      self->cap,
+  };
+  memcpy(array.ptr, self->ptr, self->len * sizeof(int));
+  return array;
+}
+
+static void IntArray_destroy(IntArray* self) {
+  free(self->ptr);
+  self->ptr = (int*)0x5a5a5a5a00;
+}
+
+static void IntArray_push(IntArray* self, int val) {
+  if (self->len == self->cap) {
+    if (self->cap == 0) {
+      self->cap = 8;
+      self->ptr = malloc(self->cap * sizeof(int));
+    } else {
+      self->cap *= 2;
+      self->ptr = realloc(self->ptr, self->cap * sizeof(int));
+    }
+  }
+  self->ptr[self->len] = val;
+  ++self->len;
+}
+
+static void IntArray_dump(const IntArray* self) {
+  printf("%p[%zu:%zu] {", self->ptr, self->len, self->cap);
+  for (size_t i = 0; i < self->len; ++i) {
+    if (i != 0) {
+      printf(", %d", self->ptr[i]);
+    } else {
+      printf("%d", self->ptr[i]);
+    }
+  }
+  printf("}");
+}
+
+static inline void kIntArrayPolicy_copy(void* dst, const void* src) {
+  typedef struct {
+    IntArray k;
+    float v;
+  } entry;
+  const entry* e = (const entry*)src;
+  entry* d = (entry*)dst;
+
+  d->k = IntArray_dup(&e->k);
+  d->v = e->v;
+}
+static inline void kIntArrayPolicy_dtor(void* val) {
+  IntArray_destroy((IntArray*)val);
+}
+
+static inline size_t kIntArrayPolicy_hash(const void* val) {
+  const IntArray* arr = (const IntArray*)val;
+  CWISS_FxHash_State state = 0;
+  CWISS_FxHash_Write(&state, &arr->len, sizeof(arr->len));
+  CWISS_FxHash_Write(&state, arr->ptr, arr->len * sizeof(int));
+  return state;
+}
+static inline bool kIntArrayPolicy_eq(const void* a, const void* b) {
+  const IntArray* ap = (const IntArray*)a;
+  const IntArray* bp = (const IntArray*)b;
+  return ap->len == bp->len &&
+         memcmp(ap->ptr, bp->ptr, ap->len * sizeof(int)) == 0;
+}
+
+CWISS_DECLARE_NODE_MAP_POLICY(kIntArrayPolicy, IntArray, float,
+                              (obj_copy, kIntArrayPolicy_copy),
+                              (obj_dtor, kIntArrayPolicy_dtor),
+                              (key_hash, kIntArrayPolicy_hash),
+                              (key_eq, kIntArrayPolicy_eq));
+
+CWISS_DECLARE_HASHMAP_WITH(MyArrayMap, IntArray, float, kIntArrayPolicy);
+
+static inline size_t MyArrayMap_IntView_hash(const IntView* self) {
+  CWISS_FxHash_State state = 0;
+  CWISS_FxHash_Write(&state, &self->len, sizeof(self->len));
+  CWISS_FxHash_Write(&state, self->ptr, self->len * sizeof(int));
+  return state;
+}
+
+static inline bool MyArrayMap_IntView_eq(const IntView* self,
+                                         const MyArrayMap_Entry* that) {
+  IntArray_dump(&that->key);
+  return self->len == that->key.len &&
+         memcmp(self->ptr, that->key.ptr, self->len * sizeof(int)) == 0;
+}
+
+CWISS_DECLARE_LOOKUP(MyArrayMap, IntView);
+
+int main(void) {
+  MyArrayMap map = MyArrayMap_new(8);
+  IntArray arr = IntArray_new();
+
+  for (int i = 0; i < 8; ++i) {
+    IntArray_push(&arr, i);
+    IntArray_dump(&arr);
+    printf("\n");
+
+    int val = i * i + 1;
+    MyArrayMap_Entry e = {arr, sin(val)};
+    // MyArrayMap_dump(&map);
+    MyArrayMap_insert(&map, &e);
+  }
+  MyArrayMap_dump(&map);
+  printf("\n");
+
+  int buf[5] = {2, 3, 4};
+  IntView k = {buf, 3};
+  assert(!MyArrayMap_contains_by_IntView(&map, &k));
+  k.ptr = arr.ptr;
+  MyArrayMap_Iter it = MyArrayMap_find_by_IntView(&map, &k);
+  MyArrayMap_Entry* v = MyArrayMap_Iter_get(&it);
+  assert(v);
+  printf("5: %p: ", v);
+  IntArray_dump(&v->key);
+  printf("->%f\n", v->val);
+
+  MyArrayMap_rehash(&map, 16);
+
+  it = MyArrayMap_find_by_IntView(&map, &k);
+  printf("5: %p: ", v);
+  IntArray_dump(&v->key);
+  printf("->%f\n", v->val);
+
+  printf("entries:\n");
+  it = MyArrayMap_iter(&map);
+  for (MyArrayMap_Entry* p = MyArrayMap_Iter_get(&it); p != NULL;
+       p = MyArrayMap_Iter_next(&it)) {
+    IntArray_dump(&p->key);
+    printf("->%f\n", p->val);
+  }
+  printf("\n");
+
+  MyArrayMap_erase_by_IntView(&map, &k);
+  assert(!MyArrayMap_contains_by_IntView(&map, &k));
+
+  printf("entries:\n");
+  it = MyArrayMap_iter(&map);
+  for (MyArrayMap_Entry* p = MyArrayMap_Iter_get(&it); p != NULL;
+       p = MyArrayMap_Iter_next(&it)) {
+    IntArray_dump(&p->key);
+    printf("->%f\n", p->val);
+  }
+  printf("\n");
+
+  MyArrayMap_dump(&map);
+  MyArrayMap_destroy(&map);
+
+  return 0;
+}

--- a/examples/stringmap.c
+++ b/examples/stringmap.c
@@ -47,15 +47,15 @@ static inline void kCStrPolicy_dtor(void* val) {
 }
 
 static inline size_t kCStrPolicy_hash(const void* val) {
-  const char* str = *(const char**)val;
+  const char* str = *(const char* const*)val;
   size_t len = strlen(str);
   CWISS_FxHash_State state = 0;
   CWISS_FxHash_Write(&state, str, len);
   return state;
 }
 static inline bool kCStrPolicy_eq(const void* a, const void* b) {
-  const char* ap = *(const char**)a;
-  const char* bp = *(const char**)b;
+  const char* ap = *(const char* const*)a;
+  const char* bp = *(const char* const*)b;
   return strcmp(ap, bp) == 0;
 }
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -12,13 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(
+    "//:copts.bzl",
+    "CWISS_DEFAULT_COPTS",
+    "CWISS_DEFAULT_LINKOPTS",
+    "CWISS_TEST_COPTS",
+    "CWISS_C_VERSION",
+    "CWISS_CXX_VERSION",
+)
+
 cc_library(
     name = "wrappers",
     hdrs = ["wrappers.h"],
     deps = ["//:unified"],
-    copts = [
-      "-std=c++17",
-    ],
+    copts = CWISS_DEFAULT_COPTS + CWISS_CXX_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
 )
 
 cc_test(
@@ -35,10 +43,8 @@ cc_test(
         "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest_main",
     ],
-    copts = [
-      "-std=c++17",
-      #"-DSWISS_HAVE_SSE2=0",
-    ],
+    copts = CWISS_TEST_COPTS + CWISS_CXX_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
 )
 
 cc_binary(
@@ -55,8 +61,6 @@ cc_binary(
         "@com_google_absl//absl/strings:str_format",
         "@com_github_google_benchmark//:benchmark_main",
     ],
-    copts = [
-      "-std=c++17",
-      #"-DSWISS_HAVE_SSE2=0",
-    ],
+    copts = CWISS_TEST_COPTS + CWISS_CXX_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
 )

--- a/test/absl_raw_hash_set_benchmark.cc
+++ b/test/absl_raw_hash_set_benchmark.cc
@@ -59,7 +59,7 @@ void BM_CacheInSteadyState(benchmark::State& state) {
     auto x = t.emplace(gen(rng));
     if (x.second) keys.push_back(*x.first);
   }
-  CWISS_CHECK(state.range(0) >= 10, "");
+  CWISS_CHECK(state.range(0) >= 10, "n/a");
   while (state.KeepRunning()) {
     // Some cache hits.
     std::deque<std::string>::const_iterator it;
@@ -69,7 +69,7 @@ void BM_CacheInSteadyState(benchmark::State& state) {
     }
     // Some cache misses.
     for (int i = 0; i != 10; ++i) ::benchmark::DoNotOptimize(t.find(gen(rng)));
-    CWISS_CHECK(t.erase(keys.front()), keys.front().c_str());
+    CWISS_CHECK(t.erase(keys.front()), keys.front().c_str(), "n/a");
     keys.pop_front();
     while (true) {
       auto x = t.emplace(gen(rng));

--- a/test/wrappers.h
+++ b/test/wrappers.h
@@ -154,7 +154,11 @@ CWISS_BIND_FUNC(NormalizeCapacity);
 CWISS_BIND_FUNC(GrowthToLowerboundCapacity);
 CWISS_BIND_FUNC(CapacityToGrowth);
 
+// GCC likes to whine about __mi128 here dropping an attribute.
+CWISS_GCC_PUSH_
+CWISS_GCC_ALLOW_("-Wignored-attributes")
 CWISS_BIND_STRUCT(Group) {
+  CWISS_GCC_POP_
   // This is actually fine because CWISS_ctrl_t is going to be a character type
   // on ~every platform.
   Group(const ctrl_t* p) : Group(reinterpret_cast<const CWISS_ctrl_t*>(p)) {}

--- a/test/wrappers.h
+++ b/test/wrappers.h
@@ -487,6 +487,7 @@ class raw_hash_set {
 
   size_t count(const key_type& key) const { return find(key) == end() ? 0 : 1; }
 
+  template <typename Key>
   iterator find(const key_type& v, size_t hash) {
     return {Inner_find_hinted(i(), &v, hash)};
   }


### PR DESCRIPTION
Adds `CWISS_DECLARE_LOOKUP` and `CWISS_DECLARE_LOOKUP_NAMED` which can be used to generate "heterogenous" lookup functions for a specific map type. For example

```c
static inline size_t MyArrayMap_IntView_hash(const IntView* self) {
  CWISS_FxHash_State state = 0;
  CWISS_FxHash_Write(&state, &self->len, sizeof(self->len));
  CWISS_FxHash_Write(&state, self->ptr, self->len * sizeof(int));
  return state;
}

static inline bool MyArrayMap_IntView_eq(const IntView* self,
                                         const MyArrayMap_Entry* that) {
  IntArray_dump(&that->key);
  return self->len == that->key.len &&
         memcmp(self->ptr, that->key.ptr, self->len * sizeof(int)) == 0;
}

CWISS_DECLARE_LOOKUP(MyArrayMap, IntView);

// ...

int buf[5] = {2, 3, 4};
IntView k = {buf, 3};
assert(!MyArrayMap_contains_by_IntView(&map, &k));
```

Also refactors some of the internals to pass around two policies inside of certain key functions.