### PR TITLE
Add deferred insertion

### DIFF
--- a/cwisstable/declare.h
+++ b/cwisstable/declare.h
@@ -144,6 +144,13 @@ CWISS_BEGIN_EXTERN_
     return &HashSet_##_##LookupName_##_kPolicy;                                \
   }                                                                            \
                                                                                \
+  static inline HashSet_##_Insert HashSet_##_deferred_insert_by_##LookupName_( \
+      HashSet_* self, const Key_* key) {                                       \
+    CWISS_Insert ret = CWISS_RawHashSet_deferred_insert(                       \
+        HashSet_##_policy(), &HashSet_##_##LookupName_##_kPolicy, &self->set_, \
+        key);                                                                  \
+    return (HashSet_##_Insert){{ret.iter}, ret.inserted};                      \
+  }                                                                            \
   static inline HashSet_##_CIter HashSet_##_cfind_hinted_by_##LookupName_(     \
       const HashSet_* self, const Key_* key, size_t hash) {                    \
     return (HashSet_##_CIter){CWISS_RawHashSet_find_hinted(                    \
@@ -269,8 +276,14 @@ CWISS_BEGIN_EXTERN_
     HashSet_##_Iter iter;                                                      \
     bool inserted;                                                             \
   } HashSet_##_Insert;                                                         \
+  static inline HashSet_##_Insert HashSet_##_deferred_insert(                  \
+      HashSet_* self, const Key_* key) {                                       \
+    CWISS_Insert ret = CWISS_RawHashSet_deferred_insert(                       \
+        &kPolicy_, kPolicy_.key, &self->set_, key);                            \
+    return (HashSet_##_Insert){{ret.iter}, ret.inserted};                      \
+  }                                                                            \
   static inline HashSet_##_Insert HashSet_##_insert(HashSet_* self,            \
-                                                    Type_* val) {              \
+                                                    const Type_* val) {        \
     CWISS_Insert ret = CWISS_RawHashSet_insert(&kPolicy_, &self->set_, val);   \
     return (HashSet_##_Insert){{ret.iter}, ret.inserted};                      \
   }                                                                            \

--- a/examples/arraymap.c
+++ b/examples/arraymap.c
@@ -40,6 +40,20 @@ typedef struct {
 
 static IntArray IntArray_new(void) { return (IntArray){0}; }
 
+static IntArray IntArray_from_view(IntView view) {
+  // This is still private API even if it's used in examples. :)
+  uint32_t width = CWISS_BitWidth(view.len);
+  uint32_t cap = (((size_t)1) << width) - 1;
+
+  IntArray array = {
+      malloc(cap * sizeof(int)),
+      view.len,
+      cap,
+  };
+  memcpy(array.ptr, view.ptr, view.len * sizeof(int));
+  return array;
+}
+
 static IntArray IntArray_dup(const IntArray* self) {
   IntArray array = {
       malloc(self->cap * sizeof(int)),
@@ -180,6 +194,12 @@ int main(void) {
 
   MyArrayMap_erase_by_IntView(&map, &k);
   assert(!MyArrayMap_contains_by_IntView(&map, &k));
+
+  MyArrayMap_Insert in = MyArrayMap_deferred_insert_by_IntView(&map, &k);
+  assert(in.inserted);
+  v = MyArrayMap_Iter_get(&in.iter);
+  v->key = IntArray_from_view(k);
+  v->val = 42;
 
   printf("entries:\n");
   it = MyArrayMap_iter(&map);


### PR DESCRIPTION
You can now insert a completely different value from the one you were going to _try_ to insert before calling `insert`; in other words, deferred insertion returns the place where the value *would have* been inserted, giving you a chance to do it your way!
```c
MyArrayMap_Insert in = MyArrayMap_deferred_insert_by_IntView(&map, &k);
assert(in.inserted);
v = MyArrayMap_Iter_get(&in.iter);
v->key = IntArray_from_view(k);
v->val = 42;
```