### PR TITLE
Port over Abseil's hash function, bringing `cwisstable`'s performance on-par with Abseil's implementation

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,12 +26,14 @@ filegroup(
     srcs = [
         "cwisstable/declare.h",
         "cwisstable/policy.h",
+        "cwisstable/hash.h",
     ],
 )
 
 filegroup(
     name = "private_headers",
     srcs = [
+        "cwisstable/internal/absl_hash.h",
         "cwisstable/internal/base.h",
         "cwisstable/internal/bits.h",
         "cwisstable/internal/capacity.h",

--- a/cwisstable/hash.h
+++ b/cwisstable/hash.h
@@ -1,0 +1,117 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CWISSTABLE_HASH_H_
+#define CWISSTABLE_HASH_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cwisstable/internal/absl_hash.h"
+#include "cwisstable/internal/base.h"
+#include "cwisstable/internal/bits.h"
+
+/// Hash functions.
+///
+/// This file provides some hash functions to use with cwisstable types.
+///
+/// Every hash function defines four symbols:
+///   - `CWISS_<Hash>_State`, the state of the hash function.
+///   - `CWISS_<Hash>_kInit`, the initial value of the hash state.
+///   - `void CWISS_<Hash>_Write(State*, const void*, size_t)`, write some more
+///     data into the hash state.
+///   - `size_t CWISS_<Hash>_Finish(State)`, digest the state into a final hash
+///     value.
+///
+/// Currently available are two hashes: `FxHash`, which is small and fast, and
+/// `AbslHash`, the hash function used by Abseil.
+///
+/// `AbslHash` is the default hash function.
+
+CWISS_BEGIN_
+CWISS_BEGIN_EXTERN_
+
+typedef size_t CWISS_FxHash_State;
+#define CWISS_FxHash_kInit ((CWISS_FxHash_State)0)
+static inline void CWISS_FxHash_Write(CWISS_FxHash_State* state,
+                                      const void* val, size_t len) {
+  const size_t kSeed = (size_t)(UINT64_C(0x517cc1b727220a95));
+  const uint32_t kRotate = 5;
+
+  const char* p = (const char*)val;
+  CWISS_FxHash_State state_ = *state;
+  while (len > 0) {
+    size_t word = 0;
+    size_t to_read = len >= sizeof(state_) ? sizeof(state_) : len;
+    memcpy(&word, p, to_read);
+
+    state_ = CWISS_RotateLeft(state_, kRotate);
+    state_ ^= word;
+    state_ *= kSeed;
+
+    len -= to_read;
+    p += to_read;
+  }
+  *state = state_;
+}
+static inline size_t CWISS_FxHash_Finish(CWISS_FxHash_State state) {
+  return state;
+}
+
+typedef CWISS_AbslHash_State_ CWISS_AbslHash_State;
+#define CWISS_AbslHash_kInit CWISS_AbslHash_kInit_
+static inline void CWISS_AbslHash_Write(CWISS_AbslHash_State* state,
+                                        const void* val, size_t len) {
+  const char* val8 = (const char*)val;
+  if (CWISS_LIKELY(len < CWISS_AbslHash_kPiecewiseChunkSize)) {
+    goto CWISS_AbslHash_Write_small;
+  }
+
+  while (len >= CWISS_AbslHash_kPiecewiseChunkSize) {
+    CWISS_AbslHash_Mix(
+        state, CWISS_AbslHash_Hash64(val8, CWISS_AbslHash_kPiecewiseChunkSize));
+    len -= CWISS_AbslHash_kPiecewiseChunkSize;
+    val8 += CWISS_AbslHash_kPiecewiseChunkSize;
+  }
+
+CWISS_AbslHash_Write_small:;
+  uint64_t v;
+  if (len > 16) {
+    v = CWISS_AbslHash_Hash64(val8, len);
+  } else if (len > 8) {
+    CWISS_U128 p = CWISS_Load9To16(val8, len);
+    CWISS_AbslHash_Mix(state, p.lo);
+    v = p.hi;
+  } else if (len >= 4) {
+    v = CWISS_Load4To8(val8, len);
+  } else if (len > 0) {
+    v = CWISS_Load1To3(val8, len);
+  } else {
+    // Empty ranges have no effect.
+    return;
+  }
+
+  CWISS_AbslHash_Mix(state, v);
+}
+static inline size_t CWISS_AbslHash_Finish(CWISS_AbslHash_State state) {
+  return state;
+}
+
+CWISS_END_EXTERN_
+CWISS_END_
+
+#endif  // CWISSTABLE_HASH_H_

--- a/cwisstable/internal/absl_hash.h
+++ b/cwisstable/internal/absl_hash.h
@@ -1,0 +1,169 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CWISSTABLE_INTERNAL_ABSL_HASH_H_
+#define CWISSTABLE_INTERNAL_ABSL_HASH_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "cwisstable/internal/base.h"
+#include "cwisstable/internal/bits.h"
+
+/// Implementation details of AbslHash.
+
+CWISS_BEGIN_
+CWISS_BEGIN_EXTERN_
+
+static inline uint64_t CWISS_AbslHash_LowLevelMix(uint64_t v0, uint64_t v1) {
+#ifndef __aarch64__
+  // The default bit-mixer uses 64x64->128-bit multiplication.
+  CWISS_U128 p = CWISS_Mul128(v0, v1);
+  return p.hi ^ p.lo;
+#else
+  // The default bit-mixer above would perform poorly on some ARM microarchs,
+  // where calculating a 128-bit product requires a sequence of two
+  // instructions with a high combined latency and poor throughput.
+  // Instead, we mix bits using only 64-bit arithmetic, which is faster.
+  uint64_t p = v0 ^ CWISS_RotateLeft(v1, 40);
+  p *= v1 ^ CWISS_RotateLeft(v0, 39);
+  return p ^ (p >> 11);
+#endif
+}
+
+CWISS_NOINLINE
+static uint64_t CWISS_AbslHash_LowLevelHash(const void* data, size_t len,
+                                            uint64_t seed,
+                                            const uint64_t salt[5]) {
+  const char* ptr = (const char*)data;
+  uint64_t starting_length = (uint64_t)len;
+  uint64_t current_state = seed ^ salt[0];
+
+  if (len > 64) {
+    // If we have more than 64 bytes, we're going to handle chunks of 64
+    // bytes at a time. We're going to build up two separate hash states
+    // which we will then hash together.
+    uint64_t duplicated_state = current_state;
+
+    do {
+      uint64_t chunk[8];
+      memcpy(chunk, ptr, sizeof(chunk));
+
+      uint64_t cs0 = CWISS_AbslHash_LowLevelMix(chunk[0] ^ salt[1],
+                                                chunk[1] ^ current_state);
+      uint64_t cs1 = CWISS_AbslHash_LowLevelMix(chunk[2] ^ salt[2],
+                                                chunk[3] ^ current_state);
+      current_state = (cs0 ^ cs1);
+
+      uint64_t ds0 = CWISS_AbslHash_LowLevelMix(chunk[4] ^ salt[3],
+                                                chunk[5] ^ duplicated_state);
+      uint64_t ds1 = CWISS_AbslHash_LowLevelMix(chunk[6] ^ salt[4],
+                                                chunk[7] ^ duplicated_state);
+      duplicated_state = (ds0 ^ ds1);
+
+      ptr += 64;
+      len -= 64;
+    } while (len > 64);
+
+    current_state = current_state ^ duplicated_state;
+  }
+
+  // We now have a data `ptr` with at most 64 bytes and the current state
+  // of the hashing state machine stored in current_state.
+  while (len > 16) {
+    uint64_t a = CWISS_Load64(ptr);
+    uint64_t b = CWISS_Load64(ptr + 8);
+
+    current_state = CWISS_AbslHash_LowLevelMix(a ^ salt[1], b ^ current_state);
+
+    ptr += 16;
+    len -= 16;
+  }
+
+  // We now have a data `ptr` with at most 16 bytes.
+  uint64_t a = 0;
+  uint64_t b = 0;
+  if (len > 8) {
+    // When we have at least 9 and at most 16 bytes, set A to the first 64
+    // bits of the input and B to the last 64 bits of the input. Yes, they will
+    // overlap in the middle if we are working with less than the full 16
+    // bytes.
+    a = CWISS_Load64(ptr);
+    b = CWISS_Load64(ptr + len - 8);
+  } else if (len > 3) {
+    // If we have at least 4 and at most 8 bytes, set A to the first 32
+    // bits and B to the last 32 bits.
+    a = CWISS_Load32(ptr);
+    b = CWISS_Load32(ptr + len - 4);
+  } else if (len > 0) {
+    // If we have at least 1 and at most 3 bytes, read all of the provided
+    // bits into A, with some adjustments.
+    a = CWISS_Load1To3(ptr, len);
+  }
+
+  uint64_t w = CWISS_AbslHash_LowLevelMix(a ^ salt[1], b ^ current_state);
+  uint64_t z = salt[1] ^ starting_length;
+  return CWISS_AbslHash_LowLevelMix(w, z);
+}
+
+// A non-deterministic seed.
+//
+// The current purpose of this seed is to generate non-deterministic results
+// and prevent having users depend on the particular hash values.
+// It is not meant as a security feature right now, but it leaves the door
+// open to upgrade it to a true per-process random seed. A true random seed
+// costs more and we don't need to pay for that right now.
+//
+// On platforms with ASLR, we take advantage of it to make a per-process
+// random value.
+// See https://en.wikipedia.org/wiki/Address_space_layout_randomization
+//
+// On other platforms this is still going to be non-deterministic but most
+// probably per-build and not per-process.
+static const void* const CWISS_AbslHash_kSeed = &CWISS_AbslHash_kSeed;
+
+// The salt array used by LowLevelHash. This array is NOT the mechanism used to
+// make absl::Hash non-deterministic between program invocations.  See `Seed()`
+// for that mechanism.
+//
+// Any random values are fine. These values are just digits from the decimal
+// part of pi.
+// https://en.wikipedia.org/wiki/Nothing-up-my-sleeve_number
+static const uint64_t CWISS_AbslHash_kHashSalt[5] = {
+    0x243F6A8885A308D3, 0x13198A2E03707344, 0xA4093822299F31D0,
+    0x082EFA98EC4E6C89, 0x452821E638D01377,
+};
+
+#define CWISS_AbslHash_kPiecewiseChunkSize ((size_t)1024)
+
+typedef uint64_t CWISS_AbslHash_State_;
+#define CWISS_AbslHash_kInit_ ((CWISS_AbslHash_State_)CWISS_AbslHash_kSeed)
+
+static inline void CWISS_AbslHash_Mix(CWISS_AbslHash_State_* state,
+                                      uint64_t v) {
+  const uint64_t kMul = sizeof(size_t) == 4 ? 0xcc9e2d51 : 0x9ddfea08eb382d69;
+  *state = CWISS_AbslHash_LowLevelMix(*state + v, kMul);
+}
+
+CWISS_NOINLINE
+static uint64_t CWISS_AbslHash_Hash64(const void* val, size_t len) {
+  return CWISS_AbslHash_LowLevelHash(val, len, CWISS_AbslHash_kInit_,
+                                     CWISS_AbslHash_kHashSalt);
+}
+
+CWISS_END_EXTERN_
+CWISS_END_
+
+#endif  // CWISSTABLE_INTERNAL_ABSL_HASH_H_

--- a/cwisstable/internal/test_helpers.h
+++ b/cwisstable/internal/test_helpers.h
@@ -25,20 +25,20 @@ namespace cwisstable {
 template <typename T>
 struct DefaultHash {
   size_t operator()(const T& val) {
-    CWISS_FxHash_State state = 0;
-    CWISS_FxHash_Write(&state, &val, sizeof(T));
-    return state;
+    CWISS_AbslHash_State state = CWISS_AbslHash_kInit;
+    CWISS_AbslHash_Write(&state, &val, sizeof(T));
+    return CWISS_AbslHash_Finish(state);
   }
 };
 
 struct HashStdString {
   template <typename S>
   size_t operator()(const S& s) {
-    CWISS_FxHash_State state = 0;
+    CWISS_AbslHash_State state = CWISS_AbslHash_kInit;
     size_t size = s.size();
-    CWISS_FxHash_Write(&state, &size, sizeof(size_t));
-    CWISS_FxHash_Write(&state, s.data(), s.size());
-    return state;
+    CWISS_AbslHash_Write(&state, &size, sizeof(size_t));
+    CWISS_AbslHash_Write(&state, s.data(), s.size());
+    return CWISS_AbslHash_Finish(state);
   }
 };
 


### PR DESCRIPTION
Results:
```
# Built with Clang 11
Comparing ../absl/bazel-bin/absl/container/raw_hash_set_benchmark to ../cwisstable/bazel-bin/cwisstable_benchmark
Benchmark                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                          +0.0028         +0.0028          2703          2711          2703          2711
BM_CacheInSteadyState/493                          +0.0010         +0.0010          2710          2713          2710          2713
BM_CacheInSteadyState/538                          -0.0025         -0.0024          2724          2717          2723          2717
BM_CacheInSteadyState/583                          -0.0027         -0.0028          2731          2724          2731          2724
BM_CacheInSteadyState/628                          +0.0519         +0.0519          2745          2887          2744          2887
BM_CacheInSteadyState/672                          +0.0072         +0.0072          2770          2790          2770          2790
BM_CacheInSteadyState/717                          +0.0040         +0.0040          2810          2822          2810          2821
BM_CacheInSteadyState/762                          -0.0016         -0.0017          2828          2823          2828          2823
BM_CacheInSteadyState/807                          -0.0071         -0.0070          2742          2722          2741          2722
BM_CacheInSteadyState/852                          +0.0043         +0.0042          2709          2721          2709          2720
BM_EndComparison/400                               +0.3364         +0.3364          1032          1380          1032          1380
BM_CopyCtor/128                                    +0.1681         +0.1680           973          1136           973          1136
BM_CopyCtor/512                                    +0.2176         +0.2177          3420          4164          3419          4164
BM_CopyCtor/4096                                   +0.7465         +0.7465         29788         52026         29786         52021
BM_RangeCtor/128                                   +0.1199         +0.1198           839           940           839           939
BM_RangeCtor/512                                   +0.1368         +0.1368          3181          3616          3180          3616
BM_RangeCtor/4096                                  +0.1198         +0.1197         26042         29162         26042         29160
BM_RangeCtor/32768                                 +0.1381         +0.1381        231990        264016        231980        264012
BM_RangeCtor/65536                                 +0.1271         +0.1271        503671        567683        503641        567668
BM_NoOpReserveIntTable                             +0.0018         +0.0020             0             0             0             0
BM_NoOpReserveStringTable                          +0.0038         +0.0038             0             0             0             0
BM_ReserveIntTable/128                             -0.0016         -0.0014           209           209           211           210
BM_ReserveIntTable/512                             -0.0225         -0.0224           204           200           206           201
BM_ReserveIntTable/4096                            +0.0079         +0.0089           247           249           249           251
BM_ReserveStringTable/128                          -0.1577         -0.1571           330           278           331           279
BM_ReserveStringTable/512                          -0.2725         -0.2719           699           508           700           510
BM_ReserveStringTable/4096                         -0.3481         -0.3480          4128          2691          4130          2692
BM_Group_Match                                     +0.3488         +0.3489             1             1             1             1
BM_Group_MatchEmpty                                +0.9604         +0.9604             0             0             0             0
BM_Group_MatchEmptyOrDeleted                       +1.0173         +1.0173             0             0             0             0
BM_Group_CountLeadingEmptyOrDeleted                -0.0343         -0.0345             1             1             1             1
BM_Group_MatchFirstEmptyOrDeleted                  -0.0021         -0.0021             1             1             1             1
BM_DropDeletes                                     +0.0219         +0.0219         31738         32431         31740         32434

# Build with GCC 10
Comparing ../absl/bazel-bin/absl/container/raw_hash_set_benchmark to ../cwisstable/bazel-bin/cwisstable_benchmark
Benchmark                                             Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                          -0.0490         -0.0490          3166          3011          3166          3011
BM_CacheInSteadyState/493                          -0.0528         -0.0528          3180          3012          3179          3012
BM_CacheInSteadyState/538                          -0.0553         -0.0553          3177          3002          3177          3001
BM_CacheInSteadyState/583                          -0.0484         -0.0484          3176          3023          3176          3022
BM_CacheInSteadyState/628                          -0.0564         -0.0564          3199          3019          3199          3019
BM_CacheInSteadyState/672                          -0.0707         -0.0707          3274          3042          3273          3042
BM_CacheInSteadyState/717                          -0.0664         -0.0665          3293          3074          3293          3074
BM_CacheInSteadyState/762                          -0.0440         -0.0440          3246          3103          3246          3103
BM_CacheInSteadyState/807                          -0.0450         -0.0449          3170          3027          3170          3027
BM_CacheInSteadyState/852                          -0.0578         -0.0577          3197          3012          3196          3012
BM_CopyCtor/128                                    +0.2766         +0.2765           824          1052           824          1052
BM_CopyCtor/512                                    +0.0623         +0.0623          4026          4276          4025          4276
BM_CopyCtor/4096                                   +0.1812         +0.1812         30176         35643         30176         35642
BM_RangeCtor/128                                   +0.7614         +0.7613           799          1408           799          1408
BM_RangeCtor/512                                   +0.7919         +0.7919          3069          5500          3069          5500
BM_RangeCtor/4096                                  +0.7932         +0.7932         24682         44261         24681         44257
BM_RangeCtor/32768                                 +0.8108         +0.8108        222593        403082        222588        403069
BM_RangeCtor/65536                                 +0.8195         +0.8195        476436        866861        476426        866837
BM_NoOpReserveIntTable                             +0.5187         +0.5188             0             1             0             1
BM_NoOpReserveStringTable                          +1.0094         +1.0096             0             1             0             1
BM_ReserveIntTable/128                             +0.1047         +0.1042           197           217           198           219
BM_ReserveIntTable/512                             -0.0018         -0.0024           204           203           205           205
BM_ReserveIntTable/4096                            +0.0150         +0.0143           252           256           254           257
BM_ReserveStringTable/128                          +0.1848         +0.1827           281           333           282           334
BM_ReserveStringTable/512                          +0.4848         +0.4835           467           694           468           695
BM_ReserveStringTable/4096                         +0.8470         +0.8464          2236          4129          2237          4131
BM_Group_Match                                     +0.0001         +0.0001             2             2             2             2
BM_Group_MatchEmpty                                -0.0047         -0.0046             2             2             2             2
BM_Group_MatchEmptyOrDeleted                       +0.0057         +0.0057             2             2             2             2
BM_Group_CountLeadingEmptyOrDeleted                +0.0039         +0.0039             2             2             2             2
BM_Group_MatchFirstEmptyOrDeleted                  +0.0018         +0.0018             2             2             2             2
BM_DropDeletes                                     +0.0218         +0.0218         32139         32839         32137         32837
```

For the key benchmark, `BM_CacheInSteadyState`, we perform no worse than Abseil within statistical uncertainty of +/-5%. Currently, we are measurably worse at copying, which may be due to sloppy porting of the benchmark in `BM_RangeCtor`.

That said, I think we can accurately conclude that `cwisstable` is a viable SwissTable implementation!