### PR TITLE
Fix build on macOS

### DIFF
--- a/copts.bzl
+++ b/copts.bzl
@@ -130,6 +130,8 @@ CWISS_LLVM_TEST_FLAGS = [
     "-Wno-used-but-marked-unused",
     "-Wno-zero-as-null-pointer-constant",
     "-Wno-gnu-zero-variadic-macro-arguments",
+    # Make sure we get all the SIMD features on tests with Clang.
+    "-march=native",
 ]
 
 CWISS_MSVC_FLAGS = [

--- a/cwisstable/internal/control_byte.h
+++ b/cwisstable/internal/control_byte.h
@@ -215,7 +215,7 @@ static inline CWISS_BitMask CWISS_Group_Match(const CWISS_Group* self,
 static inline CWISS_BitMask CWISS_Group_MatchEmpty(const CWISS_Group* self) {
   #if CWISS_HAVE_SSSE3
   // This only works because ctrl_t::kEmpty is -128.
-  return CWISS_Group_BitMask(_mm_movemask_epi8(_mm_sign_epi8(*self, *self))
+  return CWISS_Group_BitMask(_mm_movemask_epi8(_mm_sign_epi8(*self, *self)));
   #else
   return CWISS_Group_Match(self, CWISS_kEmpty);
   #endif

--- a/unify.py
+++ b/unify.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
There were two issues preventing cwisstable from building on macos
12.2.1 (aarch64):

/bin/env does not exist, and should be /usr/bin/env. This works on
most modern Linux systems because of the /usr/bin and /bin
unification. Switching to /usr/bin/env as the canonical path adds
portability.

There was a missing `);` in cwisstable/internal/control_byte.h:128.