### PR TITLE
Add ahash as an alternative hash function

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -35,6 +35,7 @@ filegroup(
     name = "private_headers",
     srcs = [
         "cwisstable/internal/absl_hash.h",
+        "cwisstable/internal/ahash.h",
         "cwisstable/internal/base.h",
         "cwisstable/internal/bits.h",
         "cwisstable/internal/capacity.h",
@@ -145,6 +146,27 @@ cc_binary(
         "@com_google_absl//absl/cleanup",
         "@com_google_absl//absl/strings:str_format",
         "@com_github_google_benchmark//:benchmark_main",
+    ],
+    copts = CWISS_TEST_COPTS + CWISS_CXX_VERSION,
+    linkopts = CWISS_DEFAULT_LINKOPTS,
+    testonly = 1,
+)
+
+cc_binary(
+    name = "cwisstable_benchmark_no_aes",
+    srcs = ["cwisstable/cwisstable_benchmark.cc"],
+    tags = ["benchmark"],
+    deps = [
+        ":cwisstable",
+        ":debug",
+        ":test_helpers",
+        
+        "@com_google_absl//absl/cleanup",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_github_google_benchmark//:benchmark_main",
+    ],
+    defines = [
+        "CWISS_HAVE_AES=0",
     ],
     copts = CWISS_TEST_COPTS + CWISS_CXX_VERSION,
     linkopts = CWISS_DEFAULT_LINKOPTS,

--- a/cwisstable/cwisstable_benchmark.cc
+++ b/cwisstable/cwisstable_benchmark.cc
@@ -41,7 +41,7 @@ struct StringGen {
   template <class Gen>
   std::string operator()(Gen& rng) const {
     std::string res;
-    res.resize(12);
+    res.resize(size);
     std::uniform_int_distribution<uint32_t> printable_ascii(0x20, 0x7E);
     std::generate(res.begin(), res.end(), [&] { return printable_ascii(rng); });
     return res;
@@ -56,7 +56,7 @@ struct StringGen {
 void BM_CacheInSteadyState(benchmark::State& state) {
   std::random_device rd;
   std::mt19937 rng(rd());
-  StringGen gen{12};
+  StringGen gen{64};
   auto t = StringTable_new(0);
   absl::Cleanup c_ = [&] { StringTable_destroy(&t); };
 

--- a/cwisstable/internal/ahash.h
+++ b/cwisstable/internal/ahash.h
@@ -1,0 +1,195 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CWISSTABLE_INTERNAL_AES_HASH_H_
+#define CWISSTABLE_INTERNAL_AES_HASH_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "cwisstable/internal/base.h"
+#include "cwisstable/internal/bits.h"
+
+/// Implementation details of aHash.
+///
+/// Based on the Apache-2.0-licensed code found at
+/// https://github.com/tkaitchuck/aHash/blob/master/src/aes_hash.rs
+
+CWISS_BEGIN
+CWISS_BEGIN_EXTERN
+
+#if CWISS_HAVE_AES
+
+typedef struct {
+  CWISS_U128 enc_, sum_, key_;
+} CWISS_AHash_State_;
+
+  // This is a keyed hash, so it requires "random" inputs. However, because
+  // its cryptographic power is unproven, we use constants for the initial value
+  // to avoid the overhead of randomness. You are welcome to inject randomness
+  // into your build system by defining these constants via
+  // -DCWISS_AHash_kInitN_.
+  //
+  // These numbers are the first eight SHA-256 round constants.
+
+  #if !defined(CWISS_AHash_kInit0_) && !defined(CWISS_AHash_kInit1_) && \
+      !defined(CWISS_AHash_kInit2_) && !defined(CWISS_AHash_kInit3_)
+    #define CWISS_AHash_kInit0_ ((uint64_t)0x71374491428a2f98)
+    #define CWISS_AHash_kInit1_ ((uint64_t)0xe9b5dba5b5c0fbcf)
+    #define CWISS_AHash_kInit2_ ((uint64_t)0x59f111f13956c25b)
+    #define CWISS_AHash_kInit3_ ((uint64_t)0xab1c5ed5923f82a4)
+  #endif
+
+  #define CWISS_AHash_kInit_                           \
+    ((CWISS_AHash_State_){                             \
+        {CWISS_AHash_kInit0_, CWISS_AHash_kInit1_},    \
+        {CWISS_AHash_kInit2_, CWISS_AHash_kInit3_},    \
+        {                                              \
+            CWISS_AHash_kInit0_ ^ CWISS_AHash_kInit2_, \
+            CWISS_AHash_kInit1_ ^ CWISS_AHash_kInit3_, \
+        },                                             \
+    })
+
+CWISS_INLINE_ALWAYS
+static inline CWISS_U128 CWISS_AHash_AddLanes(CWISS_U128 a, CWISS_U128 b) {
+  __m128i a_, b_;
+  memcpy(&a_, &a, sizeof(a));
+  memcpy(&b_, &b, sizeof(b));
+
+  a_ = _mm_add_epi64(a_, b_);
+
+  memcpy(&a, &a_, sizeof(a));
+  return a;
+}
+
+CWISS_INLINE_ALWAYS
+static inline CWISS_U128 CWISS_AHash_ShuffleAndAdd(CWISS_U128 a, CWISS_U128 b) {
+  #if CWISS_HAVE_SSSE3
+  const uint64_t mask[2] = {0x050f0d0806090b04, 0x020a07000c01030e};
+
+  __m128i a_, b_, mask_;
+  memcpy(&a_, &a, sizeof(a));
+  memcpy(&b_, &b, sizeof(b));
+  memcpy(&mask_, &mask, sizeof(mask));
+
+  a_ = _mm_shuffle_epi8(a_, mask_);
+  a_ = _mm_add_epi64(a_, b_);
+
+  memcpy(&a, &a_, sizeof(a));
+  return a;
+  #else
+  // bswap of u128.
+  char* a_bytes = (char*)&a;
+  for (size_t i = 0; i < sizeof(a) / 2; ++i) {
+    a_bytes[i] = a_bytes[sizeof(a) - i - 1];
+  }
+
+  return CWISS_AHash_AddLanes(a, b);
+  #endif
+}
+
+CWISS_INLINE_ALWAYS
+static inline void CWISS_AHash_Mix1(CWISS_AHash_State_* self, CWISS_U128 v1) {
+  self->enc_ = CWISS_AesEnc(self->enc_, v1);
+  self->sum_ = CWISS_AHash_ShuffleAndAdd(self->sum_, v1);
+}
+
+CWISS_INLINE_ALWAYS
+static inline void CWISS_AHash_Mix2(CWISS_AHash_State_* self, CWISS_U128 v1,
+                                    CWISS_U128 v2) {
+  self->enc_ = CWISS_AesEnc(self->enc_, v1);
+  self->sum_ = CWISS_AHash_ShuffleAndAdd(self->sum_, v1);
+  self->enc_ = CWISS_AesEnc(self->enc_, v2);
+  self->sum_ = CWISS_AHash_ShuffleAndAdd(self->sum_, v2);
+}
+
+static inline void CWISS_AHash_Write_(CWISS_AHash_State_* self, const void* val,
+                                      size_t len) {
+  const char* val8 = (const char*)val;
+  self->enc_.lo += len;
+
+  if (len > 64) {
+    CWISS_U128 tail[4];
+    memcpy(tail, val8 + len - sizeof(tail), sizeof(tail));
+
+    CWISS_U128 current[4] = {
+    CWISS_AesEnc(self->key_, tail[0]),
+    CWISS_AesEnc(self->key_, tail[1]),
+    CWISS_AesEnc(self->key_, tail[2]),
+    CWISS_AesEnc(self->key_, tail[3]),
+  };
+
+    CWISS_U128 sum[2] = {
+        CWISS_AHash_AddLanes(self->key_, tail[0]),
+        CWISS_AHash_AddLanes(self->key_, tail[1]),
+    };
+    sum[0] = CWISS_AHash_ShuffleAndAdd(sum[0], tail[2]);
+    sum[1] = CWISS_AHash_ShuffleAndAdd(sum[1], tail[3]);
+
+    while (len > 64) {
+      CWISS_U128 blocks[4];
+      memcpy(blocks, val8, sizeof(tail));
+      val8 += sizeof(tail);
+
+      current[0] = CWISS_AesEnc(current[0], blocks[0]);
+      current[1] = CWISS_AesEnc(current[1], blocks[1]);
+      current[2] = CWISS_AesEnc(current[2], blocks[2]);
+      current[3] = CWISS_AesEnc(current[3], blocks[3]);
+      sum[0] = CWISS_AHash_ShuffleAndAdd(sum[0], blocks[0]);
+      sum[1] = CWISS_AHash_ShuffleAndAdd(sum[1], blocks[1]);
+      sum[0] = CWISS_AHash_ShuffleAndAdd(sum[0], blocks[2]);
+      sum[1] = CWISS_AHash_ShuffleAndAdd(sum[1], blocks[3]);
+    }
+
+    CWISS_AHash_Mix2(self, CWISS_AesEnc(current[0], current[1]),
+                     CWISS_AesEnc(current[2], current[3]));
+    CWISS_AHash_Mix1(self, CWISS_AHash_AddLanes(sum[0], sum[1]));
+  } else if (len > 32) {
+    // Len 33..=64.
+    CWISS_U128 head[2];
+    CWISS_U128 tail[2];
+    memcpy(head, val8, sizeof(head));
+    memcpy(tail, val8 + len - sizeof(tail), sizeof(tail));
+    CWISS_AHash_Mix2(self, head[0], head[1]);
+    CWISS_AHash_Mix2(self, tail[0], tail[1]);
+  } else if (len > 16) {
+    // Len 17..=32.
+    CWISS_U128 head, tail;
+    memcpy(&head, val8, sizeof(head));
+    memcpy(&tail, val8 + len - sizeof(tail), sizeof(tail));
+    CWISS_AHash_Mix2(self, head, tail);
+
+  } else if (len > 8) {
+    // Len 9..=16.
+    uint64_t head, tail;
+    memcpy(&head, val8, sizeof(head));
+    memcpy(&tail, val8 + len - sizeof(tail), sizeof(tail));
+    CWISS_AHash_Mix1(self, (CWISS_U128){head, tail});
+  } else {
+    CWISS_AHash_Mix1(self, CWISS_Load0to8Twice(val, len));
+  }
+}
+
+static inline uint64_t CWISS_AHash_Finish_(CWISS_AHash_State_ self) {
+  CWISS_U128 combined = CWISS_AesDec(self.sum_, self.enc_);
+  return CWISS_AesEnc(CWISS_AesEnc(combined, self.key_), combined).lo;
+}
+
+#endif  // CWISS_HAVE_AES
+
+CWISS_END_EXTERN
+CWISS_END
+
+#endif  // CWISSTABLE_INTERNAL_AES_HASH_H_

--- a/cwisstable/internal/base.h
+++ b/cwisstable/internal/base.h
@@ -124,6 +124,18 @@
   #endif
 #endif
 
+/// `CWISS_HAVE_AES` is nonzero if we have AESNI support.
+///
+/// `-DCWISS_HAVE_AES` can be used to override it; it is otherwise detected
+/// via the usual non-portable feature-detection macros.
+#ifndef CWISS_HAVE_AES
+  #ifdef __AES__
+    #define CWISS_HAVE_AES 1
+  #else
+    #define CWISS_HAVE_AES 0
+  #endif
+#endif
+
 #if CWISS_HAVE_SSE2
   #include <emmintrin.h>
 #endif
@@ -133,6 +145,10 @@
     #error "Bad configuration: SSSE3 implies SSE2!"
   #endif
   #include <tmmintrin.h>
+#endif
+
+#if CWISS_HAVE_AES
+  #include <wmmintrin.h>
 #endif
 
 /// `CWISS_HAVE_BUILTIN` will, in Clang, detect whether a Clang language

--- a/cwisstable/internal/test_helpers.h
+++ b/cwisstable/internal/test_helpers.h
@@ -25,20 +25,20 @@ namespace cwisstable {
 template <typename T>
 struct DefaultHash {
   size_t operator()(const T& val) {
-    CWISS_AbslHash_State state = CWISS_AbslHash_kInit;
-    CWISS_AbslHash_Write(&state, &val, sizeof(T));
-    return CWISS_AbslHash_Finish(state);
+    CWISS_Hash_State state = CWISS_Hash_kInit;
+    CWISS_Hash_Write(&state, &val, sizeof(T));
+    return CWISS_Hash_Finish(state);
   }
 };
 
 struct HashStdString {
   template <typename S>
   size_t operator()(const S& s) {
-    CWISS_AbslHash_State state = CWISS_AbslHash_kInit;
+    CWISS_Hash_State state = CWISS_Hash_kInit;
     size_t size = s.size();
-    CWISS_AbslHash_Write(&state, &size, sizeof(size_t));
-    CWISS_AbslHash_Write(&state, s.data(), s.size());
-    return CWISS_AbslHash_Finish(state);
+    CWISS_Hash_Write(&state, &size, sizeof(size_t));
+    CWISS_Hash_Write(&state, s.data(), s.size());
+    return CWISS_Hash_Finish(state);
   }
 };
 

--- a/cwisstable/policy.h
+++ b/cwisstable/policy.h
@@ -251,9 +251,9 @@ typedef struct {
   }                                                                      \
   CWISS_EXTRACT_RAW(modifiers, static, __VA_ARGS__)                      \
   inline size_t kPolicy_##_DefaultHash(const void* val) {                \
-    CWISS_AbslHash_State state = CWISS_AbslHash_kInit;                   \
-    CWISS_AbslHash_Write(&state, val, sizeof(Key_));                     \
-    return CWISS_AbslHash_Finish(state);                                 \
+    CWISS_Hash_State state = CWISS_Hash_kInit;                           \
+    CWISS_Hash_Write(&state, val, sizeof(Key_));                         \
+    return CWISS_Hash_Finish(state);                                     \
   }                                                                      \
   CWISS_EXTRACT_RAW(modifiers, static, __VA_ARGS__)                      \
   inline bool kPolicy_##_DefaultEq(const void* a, const void* b) {       \


### PR DESCRIPTION
Even though my benchmarks for Rust show that ahash *destroys* absl hash, this port apparently performs up to 4x *worse*, so something is messed up in the codegen somewhere; I need to debug this.

To give an idea of what the Rust benchmarks look like:
```
absl/i64                time:   [3.0473 ms 3.0492 ms 3.0520 ms]
ahash/i64               time:   [1.5593 ms 1.5654 ms 1.5720 ms]
absl/small &[u8]        time:   [6.0225 ms 6.0371 ms 6.0561 ms]  
ahash/small &[u8]       time:   [3.5620 ms 3.5657 ms 3.5696 ms]
```

Meanwhile, the C++ benchmarks are terrible:
```
CC=clang bazel run :cwisstable_benchmark -c opt
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                14795 ns        14795 ns        42799 items_per_second=67.5905k/s load_factor=0.44
BM_CacheInSteadyState/493                14791 ns        14790 ns        47326 items_per_second=67.6126k/s load_factor=0.48
BM_CacheInSteadyState/538                14816 ns        14815 ns        47223 items_per_second=67.4983k/s load_factor=0.53
BM_CacheInSteadyState/583                14810 ns        14809 ns        47305 items_per_second=67.5271k/s load_factor=0.57
BM_CacheInSteadyState/628                14844 ns        14843 ns        47164 items_per_second=67.3697k/s load_factor=0.61
BM_CacheInSteadyState/672                14837 ns        14837 ns        47116 items_per_second=67.3997k/s load_factor=0.66
BM_CacheInSteadyState/717                14874 ns        14873 ns        47026 items_per_second=67.2371k/s load_factor=0.70
BM_CacheInSteadyState/762                14929 ns        14928 ns        46896 items_per_second=66.9872k/s load_factor=0.74
BM_CacheInSteadyState/807                14793 ns        14792 ns        47508 items_per_second=67.6026k/s load_factor=0.39
BM_CacheInSteadyState/852                14832 ns        14832 ns        47399 items_per_second=67.4224k/s load_factor=0.42
BM_EndComparison/400                      1391 ns         1391 ns       505350
BM_CopyCtor/128                           1480 ns         1480 ns       467681
BM_CopyCtor/512                           6062 ns         6062 ns       117797
BM_CopyCtor/4096                         55412 ns        55407 ns        12656
BM_RangeCtor/128                          7269 ns         7269 ns        96470
BM_RangeCtor/512                         29014 ns        29012 ns        24230
BM_RangeCtor/4096                       235547 ns       235536 ns         2964
BM_RangeCtor/32768                     2022793 ns      2022756 ns          346
BM_RangeCtor/65536                     4268254 ns      4268095 ns          164
BM_NoOpReserveIntTable                   0.234 ns        0.234 ns   1000000000
BM_NoOpReserveStringTable                0.235 ns        0.235 ns   1000000000
BM_ReserveIntTable/128                     213 ns          214 ns      3291830
BM_ReserveIntTable/512                     213 ns          214 ns      3250297
BM_ReserveIntTable/4096                    264 ns          265 ns      2637759
BM_ReserveStringTable/128                  297 ns          298 ns      2349449
BM_ReserveStringTable/512                  529 ns          530 ns      1314091
BM_ReserveStringTable/4096                2770 ns         2771 ns       253236
BM_Group_Match                           0.499 ns        0.499 ns   1000000000
BM_Group_MatchEmpty                      0.471 ns        0.471 ns   1000000000
BM_Group_MatchEmptyOrDeleted             0.469 ns        0.469 ns   1000000000
BM_Group_CountLeadingEmptyOrDeleted      0.468 ns        0.467 ns   1000000000
BM_Group_MatchFirstEmptyOrDeleted        0.452 ns        0.452 ns   1000000000
BM_DropDeletes                           32202 ns        32197 ns        22220

CC=clang bazel run :cwisstable_benchmark_no_aes -c opt
----------------------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------
BM_CacheInSteadyState/448                 9684 ns         9683 ns        58926 items_per_second=103.269k/s load_factor=0.44
BM_CacheInSteadyState/493                 9693 ns         9693 ns        71853 items_per_second=103.167k/s load_factor=0.48
BM_CacheInSteadyState/538                 9708 ns         9708 ns        72320 items_per_second=103.01k/s load_factor=0.53
BM_CacheInSteadyState/583                 9714 ns         9713 ns        72044 items_per_second=102.953k/s load_factor=0.57
BM_CacheInSteadyState/628                 9721 ns         9720 ns        72163 items_per_second=102.876k/s load_factor=0.61
BM_CacheInSteadyState/672                 9750 ns         9750 ns        71999 items_per_second=102.569k/s load_factor=0.66
BM_CacheInSteadyState/717                 9760 ns         9759 ns        71722 items_per_second=102.466k/s load_factor=0.70
BM_CacheInSteadyState/762                 9837 ns         9837 ns        71413 items_per_second=101.66k/s load_factor=0.74
BM_CacheInSteadyState/807                 9696 ns         9696 ns        72910 items_per_second=103.139k/s load_factor=0.39
BM_CacheInSteadyState/852                 9699 ns         9698 ns        72519 items_per_second=103.114k/s load_factor=0.42
BM_EndComparison/400                      1322 ns         1322 ns       511558
BM_CopyCtor/128                           1093 ns         1093 ns       648516
BM_CopyCtor/512                           4528 ns         4528 ns       159269
BM_CopyCtor/4096                         45876 ns        45872 ns        15028
BM_RangeCtor/128                           868 ns          868 ns       813842
BM_RangeCtor/512                          3216 ns         3215 ns       218478
BM_RangeCtor/4096                        25949 ns        25948 ns        27169
BM_RangeCtor/32768                      242875 ns       242838 ns         2823
BM_RangeCtor/65536                      520697 ns       520687 ns         1335
BM_NoOpReserveIntTable                   0.234 ns        0.234 ns   1000000000
BM_NoOpReserveStringTable                0.233 ns        0.233 ns   1000000000
BM_ReserveIntTable/128                     206 ns          208 ns      3334134
BM_ReserveIntTable/512                     209 ns          211 ns      3322353
BM_ReserveIntTable/4096                    269 ns          270 ns      2628556
BM_ReserveStringTable/128                  298 ns          299 ns      2340071
BM_ReserveStringTable/512                  530 ns          531 ns      1323468
BM_ReserveStringTable/4096                2766 ns         2768 ns       253804
BM_Group_Match                           0.474 ns        0.474 ns   1000000000
BM_Group_MatchEmpty                      0.472 ns        0.472 ns   1000000000
BM_Group_MatchEmptyOrDeleted             0.472 ns        0.472 ns   1000000000
BM_Group_CountLeadingEmptyOrDeleted      0.469 ns        0.469 ns   1000000000
BM_Group_MatchFirstEmptyOrDeleted        0.456 ns        0.456 ns   1000000000
BM_DropDeletes                           20700 ns        20704 ns        33807
```