### PR TITLE
Avoid OSError from <> includes when running unify.py on Windows

### DIFF
--- a/unify.py
+++ b/unify.py
@@ -91,6 +91,12 @@ def main():
     new_hdrs = []
     for hdr in hdrs.values():
       for inc in hdr.includes:
+        # Passing e.g. <stdbool.h> to Path.exists on win32 results in:
+        #   OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect.
+        # Assume that any <>-style includes are system-includes that we don't
+        # want to unify anyway.
+        if '<' in inc: continue
+
         include_path = Path(inc.strip('"'))
         open_path = include_dir / include_path
 


### PR DESCRIPTION
Previously:
```
c:\...\cwisstable>python unify.py
Traceback (most recent call last):
  File "c:\...\cwisstable\unify.py", line 180, in <module>
    if __name__ == '__main__': sys.exit(main() or 0)
  File "c:\...\cwisstable\unify.py", line 97, in main
    if include_path not in hdrs and open_path.exists():
  File "C:\Program Files\Python39\lib\pathlib.py", line 1407, in exists
    self.stat()
  File "C:\Program Files\Python39\lib\pathlib.py", line 1221, in stat
    return self._accessor.stat(self)
OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: 'C:\\...\\cwisstable\\<stdbool.h>'
```
(which seems like very dumb behaviour on Python's part, but... here we are.)